### PR TITLE
feat: add structured stderr output for error diagnostics

### DIFF
--- a/docs/agent-compatibility.mdx
+++ b/docs/agent-compatibility.mdx
@@ -8,14 +8,14 @@ The universal API normalizes different coding agents into a consistent interface
 
 ## Feature Matrix
 
-| Feature | [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview)* | [Codex](https://github.com/openai/codex) | [OpenCode](https://github.com/opencode-ai/opencode) | [Amp](https://ampcode.com) |
+| Feature | [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) | [Codex](https://github.com/openai/codex) | [OpenCode](https://github.com/opencode-ai/opencode) | [Amp](https://ampcode.com) |
 |---------|:-----------:|:-----:|:--------:|:---:|
 | Stability | Stable | Stable | Experimental | Experimental |
 | Text Messages | ✓ | ✓ | ✓ | ✓ |
-| Tool Calls | —* | ✓ | ✓ | ✓ |
-| Tool Results | —* | ✓ | ✓ | ✓ |
-| Questions (HITL) | —* | | ✓ | |
-| Permissions (HITL) | —* | | ✓ | |
+| Tool Calls | ✓ | ✓ | ✓ | ✓ |
+| Tool Results | ✓ | ✓ | ✓ | ✓ |
+| Questions (HITL) | ✓ | | ✓ | |
+| Permissions (HITL) | ✓ | | ✓ | |
 | Images | | ✓ | ✓ | |
 | File Attachments | | ✓ | ✓ | |
 | Session Lifecycle | | ✓ | ✓ | |
@@ -24,9 +24,7 @@ The universal API normalizes different coding agents into a consistent interface
 | Command Execution | | ✓ | | |
 | File Changes | | ✓ | | |
 | MCP Tools | | ✓ | | |
-| Streaming Deltas | | ✓ | ✓ | |
-
-\* Coming imminently
+| Streaming Deltas | ✓ | ✓ | ✓ | |
 
 ## Feature Descriptions
 

--- a/docs/conversion.mdx
+++ b/docs/conversion.mdx
@@ -31,13 +31,13 @@ Events / Message Flow
 | session.ended          | SDKMessage.type=result       | no explicit session end (turn/completed)   | no explicit session end (session.deleted)| type=done                        |
 | message (user)         | SDKMessage.type=user         | item/completed (ThreadItem.type=userMessage)| message.updated (Message.role=user)    | type=message                     |
 | message (assistant)    | SDKMessage.type=assistant    | item/completed (ThreadItem.type=agentMessage)| message.updated (Message.role=assistant)| type=message                  |
-| message.delta          | synthetic                   | method=item/agentMessage/delta             | type=message.part.updated (delta)       | synthetic                        |
-| tool call              | synthetic from tool usage    | method=item/mcpToolCall/progress           | message.part.updated (part.type=tool)   | type=tool_call                   |
-| tool result            | synthetic from tool usage    | item/completed (tool result ThreadItem variants) | message.part.updated (part.type=tool, state=completed) | type=tool_result     |
-| permission.requested   | none                         | none                                       | type=permission.asked                   | none                             |
-| permission.resolved    | none                         | none                                       | type=permission.replied                 | none                             |
-| question.requested     | ExitPlanMode tool (synthetic)| experimental request_user_input (payload)  | type=question.asked                     | none                             |
-| question.resolved      | ExitPlanMode reply (synthetic)| experimental request_user_input (payload) | type=question.replied / question.rejected | none                          |
+| message.delta          | stream_event (partial) or synthetic | method=item/agentMessage/delta      | type=message.part.updated (delta)       | synthetic                        |
+| tool call              | type=tool_use               | method=item/mcpToolCall/progress           | message.part.updated (part.type=tool)   | type=tool_call                   |
+| tool result            | user.message.content.tool_result | item/completed (tool result ThreadItem variants) | message.part.updated (part.type=tool, state=completed) | type=tool_result     |
+| permission.requested   | control_request.can_use_tool | none                                      | type=permission.asked                   | none                             |
+| permission.resolved    | daemon reply to can_use_tool | none                                      | type=permission.replied                 | none                             |
+| question.requested     | tool_use (AskUserQuestion)  | experimental request_user_input (payload) | type=question.asked                     | none                             |
+| question.resolved      | tool_result (AskUserQuestion) | experimental request_user_input (payload) | type=question.replied / question.rejected | none                          |
 | error                  | SDKResultMessage.error       | method=error                               | type=session.error (or message error)   | type=error                        |
 +------------------------+------------------------------+--------------------------------------------+-----------------------------------------+----------------------------------+
 
@@ -50,10 +50,11 @@ Synthetics
 | session.ended                | When agent emits no explicit end   | session.ended event   | Mark source=daemon; reason may be inferred                    |
 | item_id (Claude)             | Claude provides no item IDs        | item_id               | Maintain provider_item_id map when possible                   |
 | user message (Claude)        | Claude emits only assistant output | item.completed        | Mark source=daemon; preserve raw input in event metadata       |
-| question events (Claude)     | Plan mode ExitPlanMode tool usage  | question.requested/resolved | Synthetic mapping from tool call/result                       |
+| question events (Claude)     | AskUserQuestion tool usage         | question.requested/resolved | Derived from tool_use blocks (source=agent)                   |
 | native_session_id (Codex)    | Codex uses threadId                | native_session_id     | Intentionally merged threadId into native_session_id          |
 +------------------------------+------------------------+--------------------------+--------------------------------------------------------------+
-| message.delta (Claude/Amp)   | No native deltas               | item.delta             | Synthetic delta with full message content; source=daemon       |
+| message.delta (Claude)       | No native deltas emitted        | item.delta             | Synthetic delta with full message content; source=daemon       |
+| message.delta (Amp)          | No native deltas                | item.delta             | Synthetic delta with full message content; source=daemon       |
 +------------------------------+------------------------+--------------------------+--------------------------------------------------------------+
 | message.delta (OpenCode)     | part delta before message       | item.delta             | If part arrives first, create item.started stub then delta     |
 +------------------------------+------------------------+--------------------------+--------------------------------------------------------------+
@@ -62,11 +63,12 @@ Delta handling
 
 - Codex emits agent message and other deltas (e.g., item/agentMessage/delta).
 - OpenCode emits part deltas via message.part.updated with a delta string.
-- Claude and Amp do not emit deltas in their schemas.
+- Claude can emit stream_event deltas when partial streaming is enabled; Amp does not emit deltas.
 
 Policy:
 - Always emit item.delta across all providers.
 - For providers without native deltas, emit a single synthetic delta containing the full content prior to item.completed.
+- For Claude when partial streaming is enabled, forward native deltas and skip the synthetic full-content delta.
 - For providers with native deltas, forward as-is; also emit item.completed when final content is known.
 
 Message normalization notes

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1465,8 +1465,27 @@
           "terminated_by"
         ],
         "properties": {
+          "exit_code": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Process exit code when reason is Error",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "description": "Error message when reason is Error",
+            "nullable": true
+          },
           "reason": {
             "$ref": "#/components/schemas/SessionEndReason"
+          },
+          "stderr": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StderrOutput"
+              }
+            ],
+            "nullable": true
           },
           "terminated_by": {
             "$ref": "#/components/schemas/TerminatedBy"

--- a/docs/universal-schema.mdx
+++ b/docs/universal-schema.mdx
@@ -46,7 +46,7 @@ Every event from the API is wrapped in a `UniversalEvent` envelope.
 | Type | Description | Data |
 |------|-------------|------|
 | `session.started` | Session has started | `{ metadata?: any }` |
-| `session.ended` | Session has ended | `{ reason, terminated_by }` |
+| `session.ended` | Session has ended | `{ reason, terminated_by, message?, exit_code? }` |
 
 **SessionEndedData**
 
@@ -54,6 +54,18 @@ Every event from the API is wrapped in a `UniversalEvent` envelope.
 |-------|------|--------|
 | `reason` | string | `completed`, `error`, `terminated` |
 | `terminated_by` | string | `agent`, `daemon` |
+| `message` | string? | Error message (only present when reason is `error`) |
+| `exit_code` | int? | Process exit code (only present when reason is `error`) |
+| `stderr` | StderrOutput? | Structured stderr output (only present when reason is `error`) |
+
+**StderrOutput**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `head` | string? | First 20 lines of stderr (if truncated) or full stderr (if not truncated) |
+| `tail` | string? | Last 50 lines of stderr (only present if truncated) |
+| `truncated` | boolean | Whether the output was truncated |
+| `total_lines` | int? | Total number of lines in stderr |
 
 ### Item Lifecycle
 

--- a/examples/daytona/src/daytona.ts
+++ b/examples/daytona/src/daytona.ts
@@ -1,140 +1,38 @@
 import { Daytona, Image } from "@daytonaio/sdk";
 import { logInspectorUrl, runPrompt } from "@sandbox-agent/example-shared";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
-
-// Extract API key from Claude's config files
-function getAnthropicApiKey(): string | undefined {
-	if (process.env.ANTHROPIC_API_KEY) return process.env.ANTHROPIC_API_KEY;
-
-	const home = homedir();
-	const configPaths = [
-		join(home, ".claude.json"),
-		join(home, ".claude.json.api"),
-	];
-
-	for (const path of configPaths) {
-		try {
-			const data = JSON.parse(readFileSync(path, "utf-8"));
-			const key = data.primaryApiKey || data.apiKey || data.anthropicApiKey;
-			if (key?.startsWith("sk-ant-")) return key;
-		} catch {
-			// Ignore errors
-		}
-	}
-	return undefined;
-}
-
-const anthropicKey = getAnthropicApiKey();
-const openaiKey = process.env.OPENAI_API_KEY;
-
-if (!process.env.DAYTONA_API_KEY || (!anthropicKey && !openaiKey)) {
-	throw new Error(
-		"DAYTONA_API_KEY and (ANTHROPIC_API_KEY or OPENAI_API_KEY) required",
-	);
-}
-
-console.log(
-	"\x1b[33m[NOTE]\x1b[0m Daytona Tier 3+ required to access api.anthropic.com and api.openai.com.\n" +
-		"       Tier 1/2 sandboxes have restricted network access that will cause 'Agent Process Exited' errors.\n" +
-		"       See: https://www.daytona.io/docs/en/network-limits/\n",
-);
-
-const SNAPSHOT = "sandbox-agent-ready-v2";
 
 const daytona = new Daytona();
 
-const hasSnapshot = await daytona.snapshot.get(SNAPSHOT).then(
-	() => true,
-	() => false,
-);
-if (!hasSnapshot) {
-	console.log(`Creating snapshot '${SNAPSHOT}' (one-time setup, ~2-3min)...`);
-	await daytona.snapshot.create(
-		{
-			name: SNAPSHOT,
-			image: Image.base("ubuntu:22.04").runCommands(
-				// Install dependencies
-				"apt-get update && apt-get install -y curl ca-certificates",
-				// Install sandbox-agent
-				"curl -fsSL https://releases.rivet.dev/sandbox-agent/latest/install.sh | sh",
-				// Install agents
-				"sandbox-agent install-agent claude",
-				"sandbox-agent install-agent codex",
-			),
-		},
-		{ onLogs: (log) => console.log(`  ${log}`) },
-	);
-	console.log("Snapshot created. Future runs will be instant.");
-}
-
-console.log("Creating sandbox...");
 const envVars: Record<string, string> = {};
-if (anthropicKey) envVars.ANTHROPIC_API_KEY = anthropicKey;
-if (openaiKey) envVars.OPENAI_API_KEY = openaiKey;
+if (process.env.ANTHROPIC_API_KEY) envVars.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+if (process.env.OPENAI_API_KEY) envVars.OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
-// NOTE: Tier 1/2 sandboxes have restricted network access that cannot be overridden
-// If you're on Tier 1/2 and see "Agent Process Exited", contact Daytona to whitelist
-// api.anthropic.com and api.openai.com for your organization
-// See: https://www.daytona.io/docs/en/network-limits/
-const sandbox = await daytona.create({
-	snapshot: SNAPSHOT,
-	envVars,
-});
+const image = Image.base("ubuntu:22.04").runCommands(
+	"apt-get update && apt-get install -y curl ca-certificates",
+	"curl -fsSL https://releases.rivet.dev/sandbox-agent/latest/install.sh | sh",
+);
 
-console.log("Starting server...");
+const sandbox = await daytona.create({ envVars, image });
+
 await sandbox.process.executeCommand(
 	"nohup sandbox-agent server --no-token --host 0.0.0.0 --port 3000 >/tmp/sandbox-agent.log 2>&1 &",
 );
-
-// Wait for server to be ready
-await new Promise((r) => setTimeout(r, 2000));
-
-// Debug: check environment and agent binaries
-const envCheck = await sandbox.process.executeCommand(
-	"env | grep -E 'ANTHROPIC|OPENAI' | sed 's/=.*/=<set>/'",
-);
-console.log("Sandbox env:", envCheck.result || "(none)");
-
-const binCheck = await sandbox.process.executeCommand(
-	"ls -la /root/.local/share/sandbox-agent/bin/",
-);
-console.log("Agent binaries:", binCheck.result);
-
-// Network connectivity test
-console.log("Testing network connectivity...");
-const netTest = await sandbox.process.executeCommand(
-	"curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 https://api.anthropic.com/v1/messages 2>&1 || echo 'FAILED'",
-);
-const httpCode = netTest.result?.trim();
-if (httpCode === "405" || httpCode === "401") {
-	console.log("api.anthropic.com: reachable");
-} else if (httpCode === "000" || httpCode === "FAILED" || !httpCode) {
-	console.log("\x1b[31mapi.anthropic.com: UNREACHABLE - Tier 1/2 network restriction detected\x1b[0m");
-	console.log("Claude/Codex will fail. Upgrade to Tier 3+ or contact Daytona support.");
-} else {
-	console.log(`api.anthropic.com: ${httpCode}`);
-}
 
 const baseUrl = (await sandbox.getSignedPreviewUrl(3000, 4 * 60 * 60)).url;
 logInspectorUrl({ baseUrl });
 
 const cleanup = async () => {
-	// Show server logs before cleanup
-	const logs = await sandbox.process.executeCommand(
-		"cat /tmp/sandbox-agent.log 2>/dev/null | tail -50",
-	);
-	if (logs.result) {
-		console.log("\n--- Server logs ---");
-		console.log(logs.result);
-	}
-	console.log("Cleaning up...");
 	await sandbox.delete(60);
 	process.exit(0);
 };
 process.once("SIGINT", cleanup);
 process.once("SIGTERM", cleanup);
 
-await runPrompt({ baseUrl });
+// When running as root in a container, Claude requires interactive permission prompts
+// (bypass mode is not supported). Set autoApprovePermissions: true to auto-approve,
+// or leave false for interactive prompts.
+await runPrompt({
+	baseUrl,
+	autoApprovePermissions: process.env.AUTO_APPROVE_PERMISSIONS === "true",
+});
 await cleanup();

--- a/examples/docker/src/docker.ts
+++ b/examples/docker/src/docker.ts
@@ -79,6 +79,12 @@ if (isMainModule) {
     process.exit(0);
   });
 
-  await runPrompt({ baseUrl });
+  // When running as root in a container, Claude requires interactive permission prompts
+  // (bypass mode is not supported). Set autoApprovePermissions: true to auto-approve,
+  // or leave false for interactive prompts.
+  await runPrompt({
+    baseUrl,
+    autoApprovePermissions: process.env.AUTO_APPROVE_PERMISSIONS === "true",
+  });
   await cleanup();
 }

--- a/examples/e2b/src/e2b.ts
+++ b/examples/e2b/src/e2b.ts
@@ -60,6 +60,12 @@ if (isMainModule) {
     process.exit(0);
   });
 
-  await runPrompt({ baseUrl });
+  // When running as root in a container, Claude requires interactive permission prompts
+  // (bypass mode is not supported). Set autoApprovePermissions: true to auto-approve,
+  // or leave false for interactive prompts.
+  await runPrompt({
+    baseUrl,
+    autoApprovePermissions: process.env.AUTO_APPROVE_PERMISSIONS === "true",
+  });
   await cleanup();
 }

--- a/examples/shared/src/sandbox-agent-client.ts
+++ b/examples/shared/src/sandbox-agent-client.ts
@@ -1,7 +1,8 @@
-import { createInterface } from "node:readline/promises";
+import { createInterface, Interface } from "node:readline/promises";
 import { randomUUID } from "node:crypto";
 import { setTimeout as delay } from "node:timers/promises";
 import { SandboxAgent } from "sandbox-agent";
+import type { PermissionReply, PermissionEventData, QuestionEventData } from "sandbox-agent";
 
 export function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/+$/, "");
@@ -278,17 +279,84 @@ function detectAgent(): string {
   return "claude";
 }
 
-export async function runPrompt({
-  baseUrl,
-  token,
-  extraHeaders,
-  agentId,
-}: {
+export type PermissionHandler = (
+  data: PermissionEventData
+) => Promise<PermissionReply> | PermissionReply;
+
+export type QuestionHandler = (
+  data: QuestionEventData
+) => Promise<string[][] | null> | string[][] | null;
+
+export interface RunPromptOptions {
   baseUrl: string;
   token?: string;
   extraHeaders?: Record<string, string>;
   agentId?: string;
-}): Promise<void> {
+  agentMode?: string;
+  permissionMode?: string;
+  model?: string;
+  /** Auto-approve all permissions with "once" (default: false, prompts interactively) */
+  autoApprovePermissions?: boolean;
+  /** Custom permission handler (overrides autoApprovePermissions) */
+  onPermission?: PermissionHandler;
+  /** Custom question handler (return null to reject) */
+  onQuestion?: QuestionHandler;
+}
+
+async function promptForPermission(
+  rl: Interface,
+  data: PermissionEventData
+): Promise<PermissionReply> {
+  console.log(`\n[Permission Required] ${data.action}`);
+  if (data.metadata) {
+    console.log(`  Details: ${JSON.stringify(data.metadata, null, 2)}`);
+  }
+  while (true) {
+    const answer = await rl.question("  Allow? [y]es / [n]o / [a]lways: ");
+    const lower = answer.trim().toLowerCase();
+    if (lower === "y" || lower === "yes") return "once";
+    if (lower === "a" || lower === "always") return "always";
+    if (lower === "n" || lower === "no") return "reject";
+    console.log("  Please enter y, n, or a");
+  }
+}
+
+async function promptForQuestion(
+  rl: Interface,
+  data: QuestionEventData
+): Promise<string[][] | null> {
+  console.log(`\n[Question] ${data.prompt}`);
+  if (data.options.length > 0) {
+    console.log("  Options:");
+    data.options.forEach((opt, i) => console.log(`    ${i + 1}. ${opt}`));
+    const answer = await rl.question("  Enter option number (or 'skip' to reject): ");
+    if (answer.trim().toLowerCase() === "skip") return null;
+    const idx = parseInt(answer.trim(), 10) - 1;
+    if (idx >= 0 && idx < data.options.length) {
+      return [[data.options[idx]]];
+    }
+    console.log("  Invalid option, rejecting question");
+    return null;
+  }
+  const answer = await rl.question("  Your answer (or 'skip' to reject): ");
+  if (answer.trim().toLowerCase() === "skip") return null;
+  return [[answer.trim()]];
+}
+
+export async function runPrompt(options: RunPromptOptions): Promise<void> {
+  const {
+    baseUrl,
+    token,
+    extraHeaders,
+    agentId,
+    agentMode,
+    permissionMode,
+    model,
+    autoApprovePermissions = false,
+    onPermission,
+    onQuestion,
+  } = options;
+
   const client = await SandboxAgent.connect({
     baseUrl,
     token,
@@ -296,14 +364,60 @@ export async function runPrompt({
   });
 
   const agent = agentId || detectAgent();
+  console.log(`Using agent: ${agent}`);
   const sessionId = randomUUID();
-  await client.createSession(sessionId, { agent });
-  console.log(`Session ${sessionId} using ${agent}. Press Ctrl+C to quit.`);
+  await client.createSession(sessionId, {
+    agent,
+    agentMode,
+    permissionMode,
+    model,
+  });
+  console.log(`Session ${sessionId}. Press Ctrl+C to quit.`);
+
+  // Create readline interface for interactive prompts
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
 
   let isThinking = false;
   let hasStartedOutput = false;
   let turnResolve: (() => void) | null = null;
   let sessionEnded = false;
+
+  // Handle permission request
+  const handlePermission = async (data: PermissionEventData): Promise<void> => {
+    try {
+      let reply: PermissionReply;
+      if (onPermission) {
+        reply = await onPermission(data);
+      } else if (autoApprovePermissions) {
+        console.log(`\n[Auto-approved] ${data.action}`);
+        reply = "once";
+      } else {
+        reply = await promptForPermission(rl, data);
+      }
+      await client.replyPermission(sessionId, data.permission_id, { reply });
+    } catch (err) {
+      console.error("Failed to reply to permission:", err instanceof Error ? err.message : err);
+    }
+  };
+
+  // Handle question request
+  const handleQuestion = async (data: QuestionEventData): Promise<void> => {
+    try {
+      let answers: string[][] | null;
+      if (onQuestion) {
+        answers = await onQuestion(data);
+      } else {
+        answers = await promptForQuestion(rl, data);
+      }
+      if (answers === null) {
+        await client.rejectQuestion(sessionId, data.question_id);
+      } else {
+        await client.replyQuestion(sessionId, data.question_id, { answers });
+      }
+    } catch (err) {
+      console.error("Failed to reply to question:", err instanceof Error ? err.message : err);
+    }
+  };
 
   // Stream events in background using SDK
   const processEvents = async () => {
@@ -342,6 +456,26 @@ export async function runPrompt({
         }
       }
 
+      // Handle permission requests
+      if (event.type === "permission.requested") {
+        const data = event.data as PermissionEventData;
+        // Clear thinking indicator if shown
+        if (isThinking && !hasStartedOutput) {
+          process.stdout.write("\r\x1b[K");
+        }
+        await handlePermission(data);
+      }
+
+      // Handle question requests
+      if (event.type === "question.requested") {
+        const data = event.data as QuestionEventData;
+        // Clear thinking indicator if shown
+        if (isThinking && !hasStartedOutput) {
+          process.stdout.write("\r\x1b[K");
+        }
+        await handleQuestion(data);
+      }
+
       // Handle errors
       if (event.type === "error") {
         const data = event.data as any;
@@ -351,7 +485,36 @@ export async function runPrompt({
       // Handle session ended
       if (event.type === "session.ended") {
         const data = event.data as any;
-        console.log(`Agent Process Exited${data?.reason ? `: ${data.reason}` : ""}`);
+        const reason = data?.reason || "unknown";
+        const exitCode = data?.exit_code;
+        const message = data?.message;
+        const stderr = data?.stderr;
+
+        if (reason === "error") {
+          console.error(`\nAgent exited with error:`);
+          if (exitCode !== undefined) {
+            console.error(`  Exit code: ${exitCode}`);
+          }
+          if (message) {
+            console.error(`  Message: ${message}`);
+          }
+          if (stderr) {
+            console.error(`\n--- Agent Stderr ---`);
+            if (stderr.head) {
+              console.error(stderr.head);
+            }
+            if (stderr.truncated && stderr.tail) {
+              const omitted = stderr.total_lines
+                ? stderr.total_lines - 70 // 20 head + 50 tail
+                : "...";
+              console.error(`\n... ${omitted} lines omitted ...\n`);
+              console.error(stderr.tail);
+            }
+            console.error(`--- End Stderr ---`);
+          }
+        } else {
+          console.log(`Agent session ${reason}`);
+        }
         sessionEnded = true;
         turnResolve?.();
         turnResolve = null;
@@ -365,7 +528,6 @@ export async function runPrompt({
   });
 
   // Read user input and post messages
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
   while (true) {
     const line = await rl.question("> ");
     if (!line.trim()) continue;

--- a/examples/shared/tsconfig.json
+++ b/examples/shared/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5973,14 +5973,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@22.19.7))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 5.4.21(@types/node@22.19.7)
-
   '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@25.0.10))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -8424,7 +8416,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@22.19.7))
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@25.0.10))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/research/agents/amp.md
+++ b/research/agents/amp.md
@@ -153,6 +153,10 @@ Or via SDK:
 execute(prompt, { dangerouslyAllowAll: true });
 ```
 
+### Root Restrictions
+
+**Amp has no known root restrictions** - the `--dangerously-skip-permissions` flag works regardless of user privileges. This makes Amp suitable for automated container environments that commonly run as root.
+
 ## Human-in-the-Loop
 
 ### No Interactive HITL API

--- a/research/agents/codex.md
+++ b/research/agents/codex.md
@@ -199,6 +199,12 @@ Codex separates sandbox levels (permissions) from behavioral modes (prompt prefi
 | `danger-full-access` | `-s danger-full-access` | Full system access |
 | `bypass` | `--dangerously-bypass-approvals-and-sandbox` | Skip all checks |
 
+### Root Restrictions
+
+**Codex has no root restrictions** - unlike Claude, Codex does not check if running as root (uid 0).
+
+The `--dangerously-bypass-approvals-and-sandbox` flag works regardless of user privileges. This makes Codex more suitable for automated container environments that commonly run as root.
+
 ### Agent Modes (Prompt Prefixes)
 
 Codex doesn't have true agent modes - behavior is controlled via prompt prefixing:

--- a/research/agents/opencode.md
+++ b/research/agents/opencode.md
@@ -444,6 +444,10 @@ interface PermissionRuleset {
 }
 ```
 
+### Root Restrictions
+
+**OpenCode has no known root restrictions** - it operates as an HTTP server and does not check user privileges. This makes OpenCode suitable for automated container environments that commonly run as root.
+
 ### Human-in-the-Loop
 
 OpenCode has full interactive HITL via SSE events:

--- a/sdks/typescript/src/generated/openapi.ts
+++ b/sdks/typescript/src/generated/openapi.ts
@@ -257,7 +257,15 @@ export interface components {
     /** @enum {string} */
     SessionEndReason: "completed" | "error" | "terminated";
     SessionEndedData: {
+      /**
+       * Format: int32
+       * @description Process exit code when reason is Error
+       */
+      exit_code?: number | null;
+      /** @description Error message when reason is Error */
+      message?: string | null;
       reason: components["schemas"]["SessionEndReason"];
+      stderr?: components["schemas"]["StderrOutput"] | null;
       terminated_by: components["schemas"]["TerminatedBy"];
     };
     SessionInfo: {

--- a/server/packages/agent-management/src/agents.rs
+++ b/server/packages/agent-management/src/agents.rs
@@ -217,7 +217,6 @@ impl AgentManager {
         match agent {
             AgentId::Claude => {
                 command
-                    .arg("--print")
                     .arg("--output-format")
                     .arg("stream-json")
                     .arg("--verbose");
@@ -234,9 +233,21 @@ impl AgentManager {
                     Some("bypass") => {
                         command.arg("--dangerously-skip-permissions");
                     }
+                    Some("acceptEdits") => {
+                        command.arg("--permission-mode").arg("acceptEdits");
+                    }
                     _ => {}
                 }
-                command.arg(&options.prompt);
+                if options.streaming_input {
+                    command
+                        .arg("--input-format")
+                        .arg("stream-json")
+                        .arg("--permission-prompt-tool")
+                        .arg("stdio")
+                        .arg("--include-partial-messages");
+                } else {
+                    command.arg(&options.prompt);
+                }
             }
             AgentId::Codex => {
                 if options.session_id.is_some() {
@@ -305,15 +316,18 @@ impl AgentManager {
     pub fn spawn_streaming(
         &self,
         agent: AgentId,
-        options: SpawnOptions,
+        mut options: SpawnOptions,
     ) -> Result<StreamingSpawn, AgentError> {
         let codex_options = if agent == AgentId::Codex {
             Some(options.clone())
         } else {
             None
         };
+        if agent == AgentId::Claude {
+            options.streaming_input = true;
+        }
         let mut command = self.build_command(agent, &options)?;
-        if agent == AgentId::Codex {
+        if matches!(agent, AgentId::Codex | AgentId::Claude) {
             command.stdin(Stdio::piped());
         }
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
@@ -556,9 +570,21 @@ impl AgentManager {
                     Some("bypass") => {
                         command.arg("--dangerously-skip-permissions");
                     }
+                    Some("acceptEdits") => {
+                        command.arg("--permission-mode").arg("acceptEdits");
+                    }
                     _ => {}
                 }
-                command.arg(&options.prompt);
+                if options.streaming_input {
+                    command
+                        .arg("--input-format")
+                        .arg("stream-json")
+                        .arg("--permission-prompt-tool")
+                        .arg("stdio")
+                        .arg("--include-partial-messages");
+                } else {
+                    command.arg("--print").arg("--").arg(&options.prompt);
+                }
             }
             AgentId::Codex => {
                 if options.session_id.is_some() {
@@ -646,6 +672,8 @@ pub struct SpawnOptions {
     pub session_id: Option<String>,
     pub working_dir: Option<PathBuf>,
     pub env: HashMap<String, String>,
+    /// Use stream-json input via stdin (Claude only).
+    pub streaming_input: bool,
 }
 
 impl SpawnOptions {
@@ -659,6 +687,7 @@ impl SpawnOptions {
             session_id: None,
             working_dir: None,
             env: HashMap::new(),
+            streaming_input: false,
         }
     }
 }

--- a/server/packages/sandbox-agent/Cargo.toml
+++ b/server/packages/sandbox-agent/Cargo.toml
@@ -36,6 +36,9 @@ tracing-subscriber.workspace = true
 include_dir.workspace = true
 tempfile = { workspace = true, optional = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 http-body-util.workspace = true
 insta.workspace = true

--- a/server/packages/sandbox-agent/src/agent_server_logs/unix.rs
+++ b/server/packages/sandbox-agent/src/agent_server_logs/unix.rs
@@ -1,10 +1,15 @@
-use std::fs::OpenOptions;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 use sandbox_agent_error::SandboxError;
 use time::{Duration, OffsetDateTime};
+use sandbox_agent_universal_agent_schema::StderrOutput;
 
 const LOG_RETENTION_DAYS: i64 = 7;
+const LOG_HEAD_LINES: usize = 20;
+const LOG_TAIL_LINES: usize = 50;
+const LOG_MAX_LINE_LENGTH: usize = 500;
 
 pub struct AgentServerLogs {
     base_dir: PathBuf,
@@ -75,5 +80,71 @@ impl AgentServerLogs {
         }
 
         Ok(())
+    }
+
+    /// Read stderr from the current log file for error diagnostics.
+    /// Returns structured output with head/tail if truncated.
+    pub fn read_stderr(&self) -> Option<StderrOutput> {
+        let log_dir = self.base_dir.join(&self.agent);
+        let now = OffsetDateTime::now_utc();
+        let file_name = format!(
+            "{}-{:04}-{:02}-{:02}.log",
+            self.agent,
+            now.year(),
+            now.month() as u8,
+            now.day()
+        );
+        let path = log_dir.join(file_name);
+
+        let file = File::open(&path).ok()?;
+        let metadata = file.metadata().ok()?;
+        let file_size = metadata.len();
+
+        if file_size == 0 {
+            return None;
+        }
+
+        let reader = BufReader::new(file);
+        let mut all_lines: Vec<String> = Vec::new();
+
+        for line_result in reader.lines() {
+            let line: String = match line_result {
+                Ok(l) => l,
+                Err(_) => break,
+            };
+            let truncated_line = if line.len() > LOG_MAX_LINE_LENGTH {
+                format!("{}...", &line[..LOG_MAX_LINE_LENGTH])
+            } else {
+                line
+            };
+            all_lines.push(truncated_line);
+        }
+
+        let line_count = all_lines.len();
+        if line_count == 0 {
+            return None;
+        }
+
+        let max_untruncated = LOG_HEAD_LINES + LOG_TAIL_LINES;
+
+        if line_count <= max_untruncated {
+            // Small file - return all content in head
+            Some(StderrOutput {
+                head: Some(all_lines.join("\n")),
+                tail: None,
+                truncated: false,
+                total_lines: Some(line_count),
+            })
+        } else {
+            // Large file - return head and tail separately
+            let head = all_lines[..LOG_HEAD_LINES].join("\n");
+            let tail = all_lines[line_count - LOG_TAIL_LINES..].join("\n");
+            Some(StderrOutput {
+                head: Some(head),
+                tail: Some(tail),
+                truncated: true,
+                total_lines: Some(line_count),
+            })
+        }
     }
 }

--- a/server/packages/sandbox-agent/tests/http/snapshots/http_endpoints__agent_endpoints__agent_endpoints_snapshots@agent_install_codex.snap
+++ b/server/packages/sandbox-agent/tests/http/snapshots/http_endpoints__agent_endpoints__agent_endpoints_snapshots@agent_install_codex.snap
@@ -1,0 +1,5 @@
+---
+source: server/packages/sandbox-agent/tests/http/agent_endpoints.rs
+expression: snapshot_status(status)
+---
+status: 204

--- a/server/packages/sandbox-agent/tests/http/snapshots/http_endpoints__agent_endpoints__agent_endpoints_snapshots@agent_install_opencode.snap
+++ b/server/packages/sandbox-agent/tests/http/snapshots/http_endpoints__agent_endpoints__agent_endpoints_snapshots@agent_install_opencode.snap
@@ -1,0 +1,5 @@
+---
+source: server/packages/sandbox-agent/tests/http/agent_endpoints.rs
+expression: snapshot_status(status)
+---
+status: 204

--- a/server/packages/sandbox-agent/tests/http/snapshots/http_endpoints__agent_endpoints__agent_endpoints_snapshots@agent_modes_codex.snap
+++ b/server/packages/sandbox-agent/tests/http/snapshots/http_endpoints__agent_endpoints__agent_endpoints_snapshots@agent_modes_codex.snap
@@ -1,0 +1,11 @@
+---
+source: server/packages/sandbox-agent/tests/http/agent_endpoints.rs
+expression: normalize_agent_modes(&modes)
+---
+modes:
+  - description: true
+    id: build
+    name: Build
+  - description: true
+    id: plan
+    name: Plan

--- a/server/packages/sandbox-agent/tests/http/snapshots/http_endpoints__agent_endpoints__agent_endpoints_snapshots@agent_modes_opencode.snap
+++ b/server/packages/sandbox-agent/tests/http/snapshots/http_endpoints__agent_endpoints__agent_endpoints_snapshots@agent_modes_opencode.snap
@@ -1,0 +1,14 @@
+---
+source: server/packages/sandbox-agent/tests/http/agent_endpoints.rs
+expression: normalize_agent_modes(&modes)
+---
+modes:
+  - description: true
+    id: build
+    name: Build
+  - description: true
+    id: custom
+    name: Custom
+  - description: true
+    id: plan
+    name: Plan

--- a/server/packages/sandbox-agent/tests/sessions/snapshots/sessions__sessions__session_lifecycle__assert_session_snapshot@create_session_mock-2.snap.new
+++ b/server/packages/sandbox-agent/tests/sessions/snapshots/sessions__sessions__session_lifecycle__assert_session_snapshot@create_session_mock-2.snap.new
@@ -1,0 +1,7 @@
+---
+source: server/packages/sandbox-agent/tests/sessions/session_lifecycle.rs
+assertion_line: 12
+expression: value
+---
+healthy: true
+nativeSessionId: "<redacted>"

--- a/server/packages/universal-agent-schema/src/agents/amp.rs
+++ b/server/packages/universal-agent-schema/src/agents/amp.rs
@@ -109,6 +109,9 @@ pub fn event_to_universal(event: &schema::StreamJsonMessage) -> Result<Vec<Event
                     UniversalEventData::SessionEnded(SessionEndedData {
                         reason: SessionEndReason::Completed,
                         terminated_by: TerminatedBy::Agent,
+                        message: None,
+                        exit_code: None,
+                        stderr: None,
                     }),
                 )
                 .with_raw(serde_json::to_value(event).ok()),

--- a/server/packages/universal-agent-schema/src/agents/claude.rs
+++ b/server/packages/universal-agent-schema/src/agents/claude.rs
@@ -6,9 +6,12 @@ use crate::{
     ContentPart,
     EventConversion,
     ItemEventData,
+    ItemDeltaData,
     ItemKind,
     ItemRole,
     ItemStatus,
+    PermissionEventData,
+    PermissionStatus,
     QuestionEventData,
     QuestionStatus,
     SessionStartedData,
@@ -31,11 +34,14 @@ pub fn event_to_universal_with_session(
     let event_type = event.get("type").and_then(Value::as_str).unwrap_or("");
     let mut conversions = match event_type {
         "system" => vec![system_event_to_universal(event)],
-        "user" => Vec::new(),
+        "user" => user_event_to_universal(event),
         "assistant" => assistant_event_to_universal(event, &session_id),
         "tool_use" => tool_use_event_to_universal(event, &session_id),
         "tool_result" => tool_result_event_to_universal(event),
         "result" => result_event_to_universal(event, &session_id),
+        "stream_event" => stream_event_to_universal(event),
+        "control_request" => control_request_to_universal(event)?,
+        "control_response" | "keep_alive" | "update_environment_variables" => Vec::new(),
         _ => return Err(format!("unsupported Claude event type: {event_type}")),
     };
 
@@ -85,6 +91,44 @@ fn assistant_event_to_universal(event: &Value, session_id: &str) -> Vec<EventCon
                         .and_then(Value::as_str)
                         .map(|s| s.to_string())
                         .unwrap_or_else(|| next_temp_id("tmp_claude_tool"));
+                    let is_exit_plan_mode = matches!(
+                        name,
+                        "ExitPlanMode" | "exit_plan_mode" | "exitPlanMode" | "exit-plan-mode"
+                    );
+                    let is_question_tool = matches!(
+                        name,
+                        "AskUserQuestion" | "ask_user_question" | "askUserQuestion"
+                            | "ask-user-question"
+                    ) || is_exit_plan_mode;
+                    let has_question_payload = input.get("questions").is_some();
+                    if is_question_tool || has_question_payload {
+                        if let Some(question) = question_from_claude_input(&input, call_id.clone()) {
+                            conversions.push(
+                                EventConversion::new(
+                                    UniversalEventType::QuestionRequested,
+                                    UniversalEventData::Question(question),
+                                )
+                                .with_raw(Some(event.clone())),
+                            );
+                        } else if is_exit_plan_mode {
+                            conversions.push(
+                                EventConversion::new(
+                                    UniversalEventType::QuestionRequested,
+                                    UniversalEventData::Question(QuestionEventData {
+                                        question_id: call_id.clone(),
+                                        prompt: "Approve plan execution?".to_string(),
+                                        options: vec![
+                                            "approve".to_string(),
+                                            "reject".to_string(),
+                                        ],
+                                        response: None,
+                                        status: QuestionStatus::Requested,
+                                    }),
+                                )
+                                .with_raw(Some(event.clone())),
+                            );
+                        }
+                    }
                     let arguments = serde_json::to_string(&input).unwrap_or_else(|_| "{}".to_string());
                     let tool_item = UniversalItem {
                         item_id: String::new(),
@@ -120,7 +164,49 @@ fn assistant_event_to_universal(event: &Value, session_id: &str) -> Vec<EventCon
         status: ItemStatus::InProgress,
     };
 
-    conversions.extend(message_started_events(message_item, message_parts));
+    conversions.extend(message_started_events(message_item));
+    conversions
+}
+
+fn user_event_to_universal(event: &Value) -> Vec<EventConversion> {
+    let mut conversions = Vec::new();
+    let content = event
+        .get("message")
+        .and_then(|msg| msg.get("content"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    for block in content {
+        let block_type = block.get("type").and_then(Value::as_str).unwrap_or("");
+        if block_type != "tool_result" {
+            continue;
+        }
+
+        let tool_use_id = block
+            .get("tool_use_id")
+            .or_else(|| block.get("toolUseId"))
+            .and_then(Value::as_str)
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| next_temp_id("tmp_claude_tool"));
+        let output = block.get("content").cloned().unwrap_or(Value::Null);
+        let output_text = serde_json::to_string(&output).unwrap_or_default();
+
+        let tool_item = UniversalItem {
+            item_id: next_temp_id("tmp_claude_tool_result"),
+            native_item_id: Some(tool_use_id.clone()),
+            parent_id: None,
+            kind: ItemKind::ToolResult,
+            role: Some(ItemRole::Tool),
+            content: vec![ContentPart::ToolResult {
+                call_id: tool_use_id,
+                output: output_text,
+            }],
+            status: ItemStatus::Completed,
+        };
+        conversions.extend(item_events(tool_item, true));
+    }
+
     conversions
 }
 
@@ -141,10 +227,14 @@ fn tool_use_event_to_universal(event: &Value, session_id: &str) -> Vec<EventConv
         .map(|s| s.to_string())
         .unwrap_or_else(|| next_temp_id("tmp_claude_tool"));
 
+    let is_exit_plan_mode = matches!(
+        name,
+        "ExitPlanMode" | "exit_plan_mode" | "exitPlanMode" | "exit-plan-mode"
+    );
     let is_question_tool = matches!(
         name,
         "AskUserQuestion" | "ask_user_question" | "askUserQuestion" | "ask-user-question"
-    );
+    ) || is_exit_plan_mode;
     let has_question_payload = input.get("questions").is_some();
     if is_question_tool || has_question_payload {
         if let Some(question) = question_from_claude_input(&input, id.clone()) {
@@ -152,6 +242,20 @@ fn tool_use_event_to_universal(event: &Value, session_id: &str) -> Vec<EventConv
                 EventConversion::new(
                     UniversalEventType::QuestionRequested,
                     UniversalEventData::Question(question),
+                )
+                .with_raw(Some(event.clone())),
+            );
+        } else if is_exit_plan_mode {
+            conversions.push(
+                EventConversion::new(
+                    UniversalEventType::QuestionRequested,
+                    UniversalEventData::Question(QuestionEventData {
+                        question_id: id.clone(),
+                        prompt: "Approve plan execution?".to_string(),
+                        options: vec!["approve".to_string(), "reject".to_string()],
+                        response: None,
+                        status: QuestionStatus::Requested,
+                    }),
                 )
                 .with_raw(Some(event.clone())),
             );
@@ -226,6 +330,88 @@ fn tool_result_event_to_universal(event: &Value) -> Vec<EventConversion> {
     conversions
 }
 
+fn stream_event_to_universal(event: &Value) -> Vec<EventConversion> {
+    let mut conversions = Vec::new();
+    let Some(raw_event) = event.get("event").and_then(Value::as_object) else {
+        return conversions;
+    };
+    let event_type = raw_event.get("type").and_then(Value::as_str).unwrap_or("");
+    if event_type != "content_block_delta" {
+        return conversions;
+    }
+    let delta_text = raw_event
+        .get("delta")
+        .and_then(|delta| delta.get("text"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if delta_text.is_empty() {
+        return conversions;
+    }
+
+    conversions.push(EventConversion::new(
+        UniversalEventType::ItemDelta,
+        UniversalEventData::ItemDelta(ItemDeltaData {
+            item_id: String::new(),
+            native_item_id: None,
+            delta: delta_text.to_string(),
+        }),
+    ));
+
+    conversions
+}
+
+fn control_request_to_universal(event: &Value) -> Result<Vec<EventConversion>, String> {
+    let request_id = event
+        .get("request_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "missing request_id".to_string())?;
+    let request = event
+        .get("request")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "missing request".to_string())?;
+    let subtype = request
+        .get("subtype")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+
+    if subtype != "can_use_tool" {
+        return Err(format!("unsupported Claude control_request subtype: {subtype}"));
+    }
+
+    let tool_name = request
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let input = request.get("input").cloned().unwrap_or(Value::Null);
+    let permission_suggestions = request
+        .get("permission_suggestions")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let blocked_path = request
+        .get("blocked_path")
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    let metadata = serde_json::json!({
+        "toolName": tool_name,
+        "input": input,
+        "permissionSuggestions": permission_suggestions,
+        "blockedPath": blocked_path,
+    });
+
+    let permission = PermissionEventData {
+        permission_id: request_id.to_string(),
+        action: tool_name.to_string(),
+        status: PermissionStatus::Requested,
+        metadata: Some(metadata),
+    };
+
+    Ok(vec![EventConversion::new(
+        UniversalEventType::PermissionRequested,
+        UniversalEventData::Permission(permission),
+    )])
+}
+
 fn result_event_to_universal(event: &Value, session_id: &str) -> Vec<EventConversion> {
     // The `result` event completes the message started by `assistant`.
     // Use the same native_item_id so they link to the same universal item.
@@ -285,7 +471,7 @@ fn item_events(item: UniversalItem, synthetic_start: bool) -> Vec<EventConversio
 
 /// Emits item.started + item.delta only (for `assistant` event).
 /// The item.completed will come from the `result` event.
-fn message_started_events(item: UniversalItem, parts: Vec<ContentPart>) -> Vec<EventConversion> {
+fn message_started_events(item: UniversalItem) -> Vec<EventConversion> {
     let mut events = Vec::new();
 
     // Emit item.started (in-progress)
@@ -293,25 +479,6 @@ fn message_started_events(item: UniversalItem, parts: Vec<ContentPart>) -> Vec<E
         UniversalEventType::ItemStarted,
         UniversalEventData::Item(ItemEventData { item: item.clone() }),
     ));
-
-    // Emit item.delta with the text content
-    let mut delta_text = String::new();
-    for part in &parts {
-        if let ContentPart::Text { text } = part {
-            delta_text.push_str(text);
-        }
-    }
-    if !delta_text.is_empty() {
-        events.push(EventConversion::new(
-            UniversalEventType::ItemDelta,
-            UniversalEventData::ItemDelta(crate::ItemDeltaData {
-                item_id: item.item_id.clone(),
-                native_item_id: item.native_item_id.clone(),
-                delta: delta_text,
-            }),
-        ));
-    }
-
     events
 }
 

--- a/server/packages/universal-agent-schema/src/agents/codex.rs
+++ b/server/packages/universal-agent-schema/src/agents/codex.rs
@@ -515,12 +515,20 @@ fn user_input_to_content(input: &schema::UserInput) -> ContentPart {
     }
 }
 
-pub fn session_ended_event(thread_id: &str, reason: SessionEndReason) -> EventConversion {
+pub fn session_ended_event(
+    thread_id: &str,
+    reason: SessionEndReason,
+    message: Option<String>,
+    exit_code: Option<i32>,
+) -> EventConversion {
     EventConversion::new(
         UniversalEventType::SessionEnded,
         UniversalEventData::SessionEnded(SessionEndedData {
             reason,
             terminated_by: TerminatedBy::Agent,
+            message,
+            exit_code,
+            stderr: None,
         }),
     )
     .with_native_session(Some(thread_id.to_string()))

--- a/server/packages/universal-agent-schema/src/lib.rs
+++ b/server/packages/universal-agent-schema/src/lib.rs
@@ -79,9 +79,33 @@ pub struct SessionStartedData {
 pub struct SessionEndedData {
     pub reason: SessionEndReason,
     pub terminated_by: TerminatedBy,
+    /// Error message when reason is Error
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    /// Process exit code when reason is Error
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    /// Agent stderr output when reason is Error
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stderr: Option<StderrOutput>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
+pub struct StderrOutput {
+    /// First N lines of stderr (if truncated) or full stderr (if not truncated)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head: Option<String>,
+    /// Last N lines of stderr (only present if truncated)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tail: Option<String>,
+    /// Whether the output was truncated
+    pub truncated: bool,
+    /// Total number of lines in stderr
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_lines: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionEndReason {
     Completed,

--- a/spec/universal-schema.json
+++ b/spec/universal-schema.json
@@ -436,8 +436,34 @@
         "terminated_by"
       ],
       "properties": {
+        "exit_code": {
+          "description": "Process exit code when reason is Error",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "message": {
+          "description": "Error message when reason is Error",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "reason": {
           "$ref": "#/definitions/SessionEndReason"
+        },
+        "stderr": {
+          "description": "Agent stderr output when reason is Error",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StderrOutput"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "terminated_by": {
           "$ref": "#/definitions/TerminatedBy"
@@ -448,6 +474,41 @@
       "type": "object",
       "properties": {
         "metadata": true
+      }
+    },
+    "StderrOutput": {
+      "type": "object",
+      "required": [
+        "truncated"
+      ],
+      "properties": {
+        "head": {
+          "description": "First N lines of stderr (if truncated) or full stderr (if not truncated)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tail": {
+          "description": "Last N lines of stderr (only present if truncated)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "total_lines": {
+          "description": "Total number of lines in stderr",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "truncated": {
+          "description": "Whether the output was truncated",
+          "type": "boolean"
+        }
       }
     },
     "TerminatedBy": {


### PR DESCRIPTION
Add StderrOutput schema with head/tail/truncated/total_lines fields to provide better error diagnostics when agent processes fail. The head captures the first 20 lines and tail captures the last 50 lines when stderr exceeds 70 lines total.

- Add StderrOutput struct to universal schema
- Update session.ended event to include stderr field
- Update TypeScript client to display structured stderr
- Regenerate OpenAPI spec and TypeScript types
- Update documentation for new schema