### PR TITLE
feat: include inspector UI in release binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,8 +25,6 @@ defaults:
 env:
   # Disable incremental compilation for faster from-scratch builds
   CARGO_INCREMENTAL: 0
-  # Skip inspector frontend for CI (not needed for type checking)
-  SANDBOX_AGENT_SKIP_INSPECTOR: 1
   # Skip OpenAPI generation in CI (use pre-committed docs/openapi.json)
   SKIP_OPENAPI_GEN: 1
 

--- a/docker/release/linux-x86_64.Dockerfile
+++ b/docker/release/linux-x86_64.Dockerfile
@@ -1,4 +1,29 @@
 # syntax=docker/dockerfile:1.10.0
+
+# Build inspector frontend
+FROM node:22-alpine AS inspector-build
+WORKDIR /app
+RUN npm install -g pnpm
+
+# Copy package files for workspaces
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY frontend/packages/inspector/package.json ./frontend/packages/inspector/
+COPY sdks/typescript/package.json ./sdks/typescript/
+
+# Install dependencies
+RUN pnpm install --filter @anthropic-ai/sdk-inspector...
+
+# Copy SDK source (with pre-generated types from docs/openapi.json)
+COPY docs/openapi.json ./docs/
+COPY sdks/typescript ./sdks/typescript
+
+# Build SDK (just tsup, skip generate since types are pre-generated)
+RUN cd sdks/typescript && SKIP_OPENAPI_GEN=1 pnpm exec tsup
+
+# Copy inspector source and build
+COPY frontend/packages/inspector ./frontend/packages/inspector
+RUN cd frontend/packages/inspector && pnpm exec vite build
+
 FROM rust:1.88.0 AS base
 
 # Install dependencies
@@ -61,12 +86,14 @@ ENV OPENSSL_DIR=/musl \
 # Copy the source code
 COPY . .
 
+# Copy pre-built inspector frontend
+COPY --from=inspector-build /app/frontend/packages/inspector/dist ./frontend/packages/inspector/dist
+
 # Build for Linux with musl (static binary) - x86_64
-# SANDBOX_AGENT_SKIP_INSPECTOR=1 skips embedding the inspector frontend
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/build/target \
-    SANDBOX_AGENT_SKIP_INSPECTOR=1 cargo build -p sandbox-agent --release --target x86_64-unknown-linux-musl && \
+    cargo build -p sandbox-agent --release --target x86_64-unknown-linux-musl && \
     mkdir -p /artifacts && \
     cp target/x86_64-unknown-linux-musl/release/sandbox-agent /artifacts/sandbox-agent-x86_64-unknown-linux-musl
 

--- a/docker/release/macos-aarch64.Dockerfile
+++ b/docker/release/macos-aarch64.Dockerfile
@@ -1,4 +1,29 @@
 # syntax=docker/dockerfile:1.10.0
+
+# Build inspector frontend
+FROM node:22-alpine AS inspector-build
+WORKDIR /app
+RUN npm install -g pnpm
+
+# Copy package files for workspaces
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY frontend/packages/inspector/package.json ./frontend/packages/inspector/
+COPY sdks/typescript/package.json ./sdks/typescript/
+
+# Install dependencies
+RUN pnpm install --filter @anthropic-ai/sdk-inspector...
+
+# Copy SDK source (with pre-generated types from docs/openapi.json)
+COPY docs/openapi.json ./docs/
+COPY sdks/typescript ./sdks/typescript
+
+# Build SDK (just tsup, skip generate since types are pre-generated)
+RUN cd sdks/typescript && SKIP_OPENAPI_GEN=1 pnpm exec tsup
+
+# Copy inspector source and build
+COPY frontend/packages/inspector ./frontend/packages/inspector
+RUN cd frontend/packages/inspector && pnpm exec vite build
+
 FROM rust:1.88.0 AS base
 
 # Install dependencies
@@ -59,12 +84,14 @@ ar = "aarch64-apple-darwin20.4-ar"\n\
 # Copy the source code
 COPY . .
 
+# Copy pre-built inspector frontend
+COPY --from=inspector-build /app/frontend/packages/inspector/dist ./frontend/packages/inspector/dist
+
 # Build for ARM64 macOS
-# SANDBOX_AGENT_SKIP_INSPECTOR=1 skips embedding the inspector frontend
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/build/target \
-    SANDBOX_AGENT_SKIP_INSPECTOR=1 cargo build -p sandbox-agent --release --target aarch64-apple-darwin && \
+    cargo build -p sandbox-agent --release --target aarch64-apple-darwin && \
     mkdir -p /artifacts && \
     cp target/aarch64-apple-darwin/release/sandbox-agent /artifacts/sandbox-agent-aarch64-apple-darwin
 

--- a/docker/release/macos-x86_64.Dockerfile
+++ b/docker/release/macos-x86_64.Dockerfile
@@ -1,4 +1,29 @@
 # syntax=docker/dockerfile:1.10.0
+
+# Build inspector frontend
+FROM node:22-alpine AS inspector-build
+WORKDIR /app
+RUN npm install -g pnpm
+
+# Copy package files for workspaces
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY frontend/packages/inspector/package.json ./frontend/packages/inspector/
+COPY sdks/typescript/package.json ./sdks/typescript/
+
+# Install dependencies
+RUN pnpm install --filter @anthropic-ai/sdk-inspector...
+
+# Copy SDK source (with pre-generated types from docs/openapi.json)
+COPY docs/openapi.json ./docs/
+COPY sdks/typescript ./sdks/typescript
+
+# Build SDK (just tsup, skip generate since types are pre-generated)
+RUN cd sdks/typescript && SKIP_OPENAPI_GEN=1 pnpm exec tsup
+
+# Copy inspector source and build
+COPY frontend/packages/inspector ./frontend/packages/inspector
+RUN cd frontend/packages/inspector && pnpm exec vite build
+
 FROM rust:1.88.0 AS base
 
 # Install dependencies
@@ -59,12 +84,14 @@ ar = "x86_64-apple-darwin20.4-ar"\n\
 # Copy the source code
 COPY . .
 
+# Copy pre-built inspector frontend
+COPY --from=inspector-build /app/frontend/packages/inspector/dist ./frontend/packages/inspector/dist
+
 # Build for x86_64 macOS
-# SANDBOX_AGENT_SKIP_INSPECTOR=1 skips embedding the inspector frontend
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/build/target \
-    SANDBOX_AGENT_SKIP_INSPECTOR=1 cargo build -p sandbox-agent --release --target x86_64-apple-darwin && \
+    cargo build -p sandbox-agent --release --target x86_64-apple-darwin && \
     mkdir -p /artifacts && \
     cp target/x86_64-apple-darwin/release/sandbox-agent /artifacts/sandbox-agent-x86_64-apple-darwin
 

--- a/docker/runtime/Dockerfile
+++ b/docker/runtime/Dockerfile
@@ -1,6 +1,32 @@
 # syntax=docker/dockerfile:1.10.0
 
 # ============================================================================
+# Build inspector frontend
+# ============================================================================
+FROM node:22-alpine AS inspector-build
+WORKDIR /app
+RUN npm install -g pnpm
+
+# Copy package files for workspaces
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY frontend/packages/inspector/package.json ./frontend/packages/inspector/
+COPY sdks/typescript/package.json ./sdks/typescript/
+
+# Install dependencies
+RUN pnpm install --filter @anthropic-ai/sdk-inspector...
+
+# Copy SDK source (with pre-generated types from docs/openapi.json)
+COPY docs/openapi.json ./docs/
+COPY sdks/typescript ./sdks/typescript
+
+# Build SDK (just tsup, skip generate since types are pre-generated)
+RUN cd sdks/typescript && SKIP_OPENAPI_GEN=1 pnpm exec tsup
+
+# Copy inspector source and build
+COPY frontend/packages/inspector ./frontend/packages/inspector
+RUN cd frontend/packages/inspector && pnpm exec vite build
+
+# ============================================================================
 # AMD64 Builder - Uses cross-tools musl toolchain
 # ============================================================================
 FROM --platform=linux/amd64 rust:1.88.0 AS builder-amd64
@@ -59,10 +85,13 @@ ENV OPENSSL_DIR=/musl \
 WORKDIR /build
 COPY . .
 
+# Copy pre-built inspector frontend
+COPY --from=inspector-build /app/frontend/packages/inspector/dist ./frontend/packages/inspector/dist
+
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/build/target \
-    SANDBOX_AGENT_SKIP_INSPECTOR=1 cargo build -p sandbox-agent --release --target x86_64-unknown-linux-musl && \
+    cargo build -p sandbox-agent --release --target x86_64-unknown-linux-musl && \
     cp target/x86_64-unknown-linux-musl/release/sandbox-agent /sandbox-agent
 
 # ============================================================================
@@ -90,10 +119,13 @@ ENV CARGO_INCREMENTAL=0 \
 WORKDIR /build
 COPY . .
 
+# Copy pre-built inspector frontend
+COPY --from=inspector-build /app/frontend/packages/inspector/dist ./frontend/packages/inspector/dist
+
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/build/target \
-    SANDBOX_AGENT_SKIP_INSPECTOR=1 cargo build -p sandbox-agent --release --target aarch64-unknown-linux-musl && \
+    cargo build -p sandbox-agent --release --target aarch64-unknown-linux-musl && \
     cp target/aarch64-unknown-linux-musl/release/sandbox-agent /sandbox-agent
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Add Node.js build stage to all release Dockerfiles to build the inspector frontend
- Copy pre-built inspector assets into Rust build stages so they get embedded in binaries
- Remove `SANDBOX_AGENT_SKIP_INSPECTOR=1` from all Dockerfiles and the release workflow

## Test plan
- [ ] Build linux-x86_64 locally: `docker/release/build.sh x86_64-unknown-linux-musl`
- [ ] Run the binary and verify inspector is embedded (should show "inspector ui available")
- [ ] Access the inspector UI at http://localhost:2468/ui/

🤖 Generated with [Claude Code](https://claude.ai/code)