### PR TITLE
fix: download binaries from R2 before npm publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ npm-debug.log*
 # Rust
 Cargo.lock
 **/*.rs.bk
+
+# CLI binaries (downloaded during npm publish)
+sdks/cli/platforms/*/bin/

--- a/scripts/release/utils.ts
+++ b/scripts/release/utils.ts
@@ -200,3 +200,15 @@ export async function assertDirExists(dirPath: string): Promise<void> {
 		throw err;
 	}
 }
+
+export async function downloadFromReleases(
+	remotePath: string,
+	localPath: string,
+): Promise<void> {
+	const { awsEnv, endpointUrl } = await getReleasesS3Config();
+	await $({
+		env: awsEnv,
+		shell: true,
+		stdio: "inherit",
+	})`aws s3 cp s3://rivet-releases/${remotePath} ${localPath} --endpoint-url ${endpointUrl}`;
+}


### PR DESCRIPTION
The npm CLI platform packages were being published without binaries
because publishNpmCli() wasn't downloading them from R2 first.

- Add downloadFromReleases() helper to utils.ts
- Update publishNpmCli() to download platform binaries before publish
- Add sdks/cli/platforms/*/bin/ to .gitignore