### PR TITLE
fix: OpenCode event streaming + bypass permission mode

### DIFF
--- a/server/packages/agent-management/src/agents.rs
+++ b/server/packages/agent-management/src/agents.rs
@@ -269,6 +269,9 @@ impl AgentManager {
                 if let Some(variant) = options.variant.as_deref() {
                     command.arg("--variant").arg(variant);
                 }
+                if options.permission_mode.as_deref() == Some("bypass") {
+                    command.arg("--dangerously-skip-permissions");
+                }
                 if let Some(session_id) = options.session_id.as_deref() {
                     command.arg("-s").arg(session_id);
                 }
@@ -601,6 +604,9 @@ impl AgentManager {
                 }
                 if let Some(variant) = options.variant.as_deref() {
                     command.arg("--variant").arg(variant);
+                }
+                if options.permission_mode.as_deref() == Some("bypass") {
+                    command.arg("--dangerously-skip-permissions");
                 }
                 if let Some(session_id) = options.session_id.as_deref() {
                     command.arg("-s").arg(session_id);


### PR DESCRIPTION
## Problem

The daemon cannot stream events from OpenCode >= 1.1.x, and `permissionMode: "bypass"` is rejected for OpenCode despite being documented. Three independent bugs:

1. **Wrong API endpoints**: Daemon calls `GET /event/subscribe` and `POST /session/{id}/prompt`, but OpenCode serves `GET /event` and `POST /session/{id}/message`. Unrecognized routes return the SPA HTML catch-all, silently failing.

2. **Untagged enum mis-dispatch**: The generated `Event` enum uses `#[serde(untagged)]`. `EventServerConnected` (variant #5) has empty properties, matching ANY event JSON before `EventMessageUpdated` (#10) is tried. All events deserialize as `ServerConnected` → `event_to_universal()` returns "unsupported opencode event".

3. **Bypass mode not wired for OpenCode**: `normalize_permission_mode()` only allows `"default"` for OpenCode, and the spawn blocks don't pass `--dangerously-skip-permissions`. OpenCode has supported this flag since 1.1.x (see anomalyco/opencode#8463).

## Fix

- Correct the two endpoint paths (`/event/subscribe` → `/event`, `/session/{id}/prompt` → `/session/{id}/message`)
- Replace `serde_json::from_value::<Event>()` with manual type-field dispatch that deserializes directly into the correct variant struct
- Allow `"bypass"` in `normalize_permission_mode()` for OpenCode
- Pass `--dangerously-skip-permissions` to OpenCode CLI when bypass mode is set (both `spawn` and `spawn_streaming`)

## Testing

Tested with OpenCode 1.1.48 + Kimi K2.5:
- Before: 0 events (HTML returned instead of JSON)
- After endpoint fixes only: 41 events, ALL `agent.unparsed`
- After all fixes: 50+ correctly parsed events (`session.started`, `item.delta` streaming, `session.idle`)
- `permissionMode: "bypass"` now accepted — `session.started` metadata confirms `"permissionMode":"bypass"`

## Files Changed

| File | Change |
|------|--------|
| `server/packages/sandbox-agent/src/router.rs` | Fix SSE + message endpoints, manual event dispatch, allow bypass mode |
| `server/packages/agent-management/src/agents.rs` | Pass `--dangerously-skip-permissions` to OpenCode CLI |

## Notes

- All npm versions (0.1.1 through 0.1.4-rc.6) ship the identical daemon binary, so these bugs exist in every released version
- The untagged enum issue is a systemic risk — any agent whose generated `Event` enum has a variant with empty/loose properties will have the same problem