### PR TITLE
fix(agent-management): pass env vars to agent in spawn_streaming

### DIFF
--- a/server/packages/agent-management/src/agents.rs
+++ b/server/packages/agent-management/src/agents.rs
@@ -327,6 +327,12 @@ impl AgentManager {
             options.streaming_input = true;
         }
         let mut command = self.build_command(agent, &options)?;
+
+        // Pass environment variables to the agent process (e.g., ANTHROPIC_API_KEY)
+        for (key, value) in &options.env {
+            command.env(key, value);
+        }
+
         if matches!(agent, AgentId::Codex | AgentId::Claude) {
             command.stdin(Stdio::piped());
         }


### PR DESCRIPTION
## Summary

- Fixes `spawn_streaming()` to pass environment variables from `SpawnOptions.env` to spawned processes
- The non-streaming `spawn()` method correctly passes env vars, but `spawn_streaming()` was missing this code path
- This caused agents like Claude to not receive `ANTHROPIC_API_KEY`, resulting in silent authentication failures

## Test plan

- [ ] Verify Claude agent receives credentials when spawned via streaming mode
- [ ] Verify Codex agent receives credentials when spawned via streaming mode
- [ ] Run existing agent integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)