### PR TITLE
feat: add raw session args/opts

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -669,7 +669,9 @@
           "mcpTools",
           "streamingDeltas",
           "itemStarted",
-          "sharedProcess"
+          "sharedProcess",
+          "rawSessionArgs",
+          "rawSessionOptions"
         ],
         "properties": {
           "commandExecution": {
@@ -701,6 +703,14 @@
           },
           "questions": {
             "type": "boolean"
+          },
+          "rawSessionArgs": {
+            "type": "boolean",
+            "description": "Whether this agent supports raw CLI arguments passed at session creation"
+          },
+          "rawSessionOptions": {
+            "type": "boolean",
+            "description": "Whether this agent supports raw options passed at session creation"
           },
           "reasoning": {
             "type": "boolean"
@@ -1074,6 +1084,20 @@
           "variant": {
             "type": "string",
             "nullable": true
+          },
+          "rawSessionArgs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "description": "Raw CLI arguments to pass to the agent (for CLI-based agents like Claude, OpenCode, Amp)"
+          },
+          "rawSessionOptions": {
+            "type": "object",
+            "additionalProperties": true,
+            "nullable": true,
+            "description": "Raw options to pass to the agent (for long-running server agents like Codex)"
           }
         }
       },

--- a/docs/sdks/typescript.mdx
+++ b/docs/sdks/typescript.mdx
@@ -62,6 +62,26 @@ await client.createSession("demo-session", {
 await client.postMessage("demo-session", { message: "Hello" });
 ```
 
+### Raw session arguments
+
+Pass low-level arguments directly to agents at session creation:
+
+```ts
+// CLI args for Claude, OpenCode, Amp (not Codex)
+await client.createSession("my-session", {
+  agent: "claude",
+  rawSessionArgs: ["--max-turns", "5"],
+});
+
+// Options passed through agent's native protocol (long-running servers only)
+await client.createSession("my-session", {
+  agent: "codex",
+  rawSessionOptions: { sandbox: "workspace-write" },
+});
+```
+
+Check `capabilities.rawSessionArgs` and `capabilities.rawSessionOptions` to see what each agent supports.
+
 List agents and inspect feature coverage (available on `capabilities`):
 
 ```ts

--- a/docs/session-transcript-schema.mdx
+++ b/docs/session-transcript-schema.mdx
@@ -29,6 +29,8 @@ This table shows which agent feature coverage appears in the universal event str
 | File Changes       |   -    |   ✓   |      -       |      -       |
 | MCP Tools          |   -    |   ✓   |      -       |      -       |
 | Streaming Deltas   |   ✓    |   ✓   |      ✓       |      -       |
+| Raw Session Args   |   ✓    |       |      ✓       |      ✓       |
+| Raw Session Options|   ✓    |   ✓   |      ✓       |      ✓       |
 
 Agents: [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) · [Codex](https://github.com/openai/codex) · [OpenCode](https://github.com/opencode-ai/opencode) · [Amp](https://ampcode.com)
 
@@ -75,6 +77,12 @@ Agents: [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
   </Accordion>
   <Accordion title="Streaming Deltas">
     Native streaming of content deltas. When not supported, the daemon emits a single synthetic delta before `item.completed`.
+  </Accordion>
+  <Accordion title="Raw Session Args">
+    Pass raw CLI arguments directly to the agent at session creation via `rawSessionArgs`. Only supported for CLI-based agents (Claude, OpenCode, Amp). Codex uses JSON-RPC, so CLI args are not applicable.
+  </Accordion>
+  <Accordion title="Raw Session Options">
+    Pass raw options to the agent at session creation via `rawSessionOptions`. For long-running server agents, options are passed through the agent's native protocol. For Codex, options are merged into the `thread/start` config.
   </Accordion>
 </AccordionGroup>
 

--- a/research/agents/amp.md
+++ b/research/agents/amp.md
@@ -25,16 +25,32 @@ amp --print --output-format stream-json --dangerously-skip-permissions "prompt"
 amp --continue SESSION_ID "follow up"
 ```
 
-### Key CLI Flags
+### Custom Args (CLI Flags)
 
-| Flag | Description |
-|------|-------------|
-| `--print` | Output mode (non-interactive) |
-| `--output-format stream-json` | JSONL streaming output |
-| `--dangerously-skip-permissions` | Skip permission prompts |
-| `--continue SESSION_ID` | Resume existing session |
-| `--model MODEL` | Specify model |
-| `--toolbox TOOLBOX` | Toolbox configuration |
+#### Core Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--print` | bool | Output mode (non-interactive) |
+| `--execute` | bool | Alternative output mode (some versions) |
+| `--output-format stream-json` | string | JSONL streaming output |
+| `--model MODEL` | string | Specify model to use |
+| `--continue SESSION_ID` | string | Resume existing session |
+
+#### Permission Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--dangerously-skip-permissions` | bool | Skip all permission prompts |
+
+#### Configuration Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--toolbox NAME` | string | Toolbox configuration to use |
+| `--mcp-config FILE` | path | Path to MCP configuration file |
+
+**Note:** Amp CLI flags vary by version. The daemon uses flag detection (`amp --help`) to determine which flags are supported before invocation.
 
 ## Credential Discovery
 

--- a/research/agents/claude.md
+++ b/research/agents/claude.md
@@ -71,17 +71,42 @@ claude \
   "PROMPT"
 ```
 
-### Arguments
+### Core Arguments
 
 | Flag | Description |
 |------|-------------|
-| `--print` | Output mode |
+| `--print` | Output mode (non-interactive) |
 | `--output-format stream-json` | Newline-delimited JSON streaming |
 | `--verbose` | Verbose output |
 | `--dangerously-skip-permissions` | Skip permission prompts |
 | `--resume SESSION_ID` | Resume existing session |
 | `--model MODEL_ID` | Specify model (e.g., `claude-sonnet-4-20250514`) |
-| `--permission-mode plan` | Plan mode (read-only exploration) |
+| `--permission-mode MODE` | Permission mode (`plan`, `acceptEdits`) |
+
+### Custom Args (Session Configuration)
+
+These flags can be passed to customize agent behavior at session start:
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--max-turns N` | int | Maximum number of agent turns before stopping |
+| `--system-prompt TEXT` | string | Custom system prompt (replaces default) |
+| `--append-system-prompt TEXT` | string | Text to append to the system prompt |
+| `--allowed-tools TOOLS` | string (comma-sep) | Comma-separated list of allowed tools |
+| `--disallowed-tools TOOLS` | string (comma-sep) | Comma-separated list of disallowed tools |
+| `--mcp-server NAME` | string | Add an MCP server by name |
+| `--timeout-secs N` | int | Timeout in seconds (overrides default 300s) |
+| `--profile NAME` | string | Use a specific configuration profile |
+
+### Streaming Input Mode Flags
+
+When using `--input-format stream-json` for streaming input:
+
+| Flag | Description |
+|------|-------------|
+| `--input-format stream-json` | Accept streaming JSON input via stdin |
+| `--permission-prompt-tool stdio` | Handle permission prompts via stdio |
+| `--include-partial-messages` | Include partial message events in output |
 
 ### Environment Variables
 

--- a/research/agents/opencode.md
+++ b/research/agents/opencode.md
@@ -34,18 +34,40 @@ opencode run -s SESSION_ID "prompt"   # Continue specific session
 opencode run -f file1.ts -f file2.ts "review these files"
 ```
 
-### Key CLI Flags
-| Flag | Description |
-|------|-------------|
-| `--format json` | Output raw JSON events (for parsing) |
-| `-m, --model PROVIDER/MODEL` | Model in format `provider/model` |
-| `--agent AGENT` | Agent to use (`build`, `plan`) |
-| `-c, --continue` | Continue last session |
-| `-s, --session ID` | Continue specific session |
-| `-f, --file FILE` | Attach file(s) to message |
-| `--attach URL` | Attach to running server |
-| `--port PORT` | Local server port |
-| `--variant VARIANT` | Reasoning effort (e.g., `high`, `max`) |
+### Custom Args (CLI Flags)
+
+#### Core Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `-m, --model PROVIDER/MODEL` | string | Model in format `provider/model` (e.g., `anthropic/claude-sonnet-4-20250514`) |
+| `--agent AGENT` | string | Agent to use (`build`, `plan`, or custom agent ID) |
+| `--format FORMAT` | enum | `default` (formatted) or `json` (raw JSON events) |
+| `--variant VARIANT` | string | Reasoning effort level (e.g., `high`, `max`, `minimal`) |
+
+#### Session Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `-c, --continue` | bool | Continue the last session |
+| `-s, --session ID` | string | Continue a specific session by ID |
+| `--title TEXT` | string | Title for the session (uses truncated prompt if omitted) |
+| `--share` | bool | Share the session publicly |
+
+#### Input/Output Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `-f, --file FILE` | path[] | Attach file(s) to message (repeatable) |
+| `--attach URL` | string | Attach to a running OpenCode server (e.g., `http://localhost:4096`) |
+| `--port PORT` | int | Port for the local server (random if not specified) |
+
+#### Debugging Flags
+
+| Flag | Type | Values | Description |
+|------|------|--------|-------------|
+| `--log-level LEVEL` | enum | `DEBUG`, `INFO`, `WARN`, `ERROR` | Log verbosity level |
+| `--print-logs` | bool | - | Print logs to stderr |
 
 ### Headless Server Mode
 ```bash

--- a/sdks/typescript/src/generated/openapi.ts
+++ b/sdks/typescript/src/generated/openapi.ts
@@ -64,6 +64,10 @@ export interface components {
       permissions: boolean;
       planMode: boolean;
       questions: boolean;
+      /** @description Whether this agent supports raw CLI arguments passed at session creation */
+      rawSessionArgs: boolean;
+      /** @description Whether this agent supports raw options passed at session creation */
+      rawSessionOptions: boolean;
       reasoning: boolean;
       sessionLifecycle: boolean;
       /** @description Whether this agent uses a shared long-running server process (vs per-turn subprocess) */
@@ -156,6 +160,12 @@ export interface components {
       model?: string | null;
       permissionMode?: string | null;
       variant?: string | null;
+      /** @description Raw CLI arguments to pass to the agent (for CLI-based agents like Claude, OpenCode, Amp) */
+      rawSessionArgs?: string[] | null;
+      /** @description Raw options to pass to the agent (for long-running server agents like Codex) */
+      rawSessionOptions?: {
+        [key: string]: unknown;
+      } | null;
     };
     CreateSessionResponse: {
       error?: components["schemas"]["AgentError"] | null;

--- a/server/packages/agent-management/src/agents.rs
+++ b/server/packages/agent-management/src/agents.rs
@@ -237,6 +237,10 @@ impl AgentManager {
                     }
                     _ => {}
                 }
+                // Apply raw CLI args
+                for arg in &options.raw_args {
+                    command.arg(arg);
+                }
                 if options.streaming_input {
                     command
                         .arg("--input-format")
@@ -267,6 +271,10 @@ impl AgentManager {
                 }
                 if let Some(session_id) = options.session_id.as_deref() {
                     command.arg("-s").arg(session_id);
+                }
+                // Apply raw CLI args
+                for arg in &options.raw_args {
+                    command.arg(arg);
                 }
                 command.arg(&options.prompt);
             }
@@ -583,6 +591,10 @@ impl AgentManager {
                     }
                     _ => {}
                 }
+                // Apply raw CLI args
+                for arg in &options.raw_args {
+                    command.arg(arg);
+                }
                 if options.streaming_input {
                     command
                         .arg("--input-format")
@@ -613,6 +625,10 @@ impl AgentManager {
                 }
                 if let Some(session_id) = options.session_id.as_deref() {
                     command.arg("-s").arg(session_id);
+                }
+                // Apply raw CLI args
+                for arg in &options.raw_args {
+                    command.arg(arg);
                 }
                 command.arg(&options.prompt);
             }
@@ -682,6 +698,8 @@ pub struct SpawnOptions {
     pub env: HashMap<String, String>,
     /// Use stream-json input via stdin (Claude only).
     pub streaming_input: bool,
+    /// Raw CLI arguments to pass to the agent (for CLI-based agents).
+    pub raw_args: Vec<String>,
 }
 
 impl SpawnOptions {
@@ -696,6 +714,7 @@ impl SpawnOptions {
             working_dir: None,
             env: HashMap::new(),
             streaming_input: false,
+            raw_args: Vec::new(),
         }
     }
 }
@@ -1054,7 +1073,12 @@ fn spawn_amp(
     if let Some(session_id) = options.session_id.as_deref() {
         command.arg("--continue").arg(session_id);
     }
-    command.args(&args).arg(&options.prompt);
+    command.args(&args);
+    // Apply raw CLI args
+    for arg in &options.raw_args {
+        command.arg(arg);
+    }
+    command.arg(&options.prompt);
     for (key, value) in &options.env {
         command.env(key, value);
     }
@@ -1094,6 +1118,10 @@ fn build_amp_command(path: &Path, working_dir: &Path, options: &SpawnOptions) ->
     }
     if flags.dangerously_skip_permissions && options.permission_mode.as_deref() == Some("bypass") {
         command.arg("--dangerously-skip-permissions");
+    }
+    // Apply raw CLI args
+    for arg in &options.raw_args {
+        command.arg(arg);
     }
     command.arg(&options.prompt);
     for (key, value) in &options.env {
@@ -1157,6 +1185,10 @@ fn spawn_amp_fallback(
         if !args.is_empty() {
             command.args(&args);
         }
+        // Apply raw CLI args
+        for arg in &options.raw_args {
+            command.arg(arg);
+        }
         command.arg(&options.prompt);
         for (key, value) in &options.env {
             command.env(key, value);
@@ -1174,6 +1206,10 @@ fn spawn_amp_fallback(
     }
     if let Some(session_id) = options.session_id.as_deref() {
         command.arg("--continue").arg(session_id);
+    }
+    // Apply raw CLI args
+    for arg in &options.raw_args {
+        command.arg(arg);
     }
     command.arg(&options.prompt);
     for (key, value) in &options.env {

--- a/server/packages/sandbox-agent/src/main.rs
+++ b/server/packages/sandbox-agent/src/main.rs
@@ -591,6 +591,8 @@ fn run_sessions(command: &SessionsCommand, cli: &Cli) -> Result<(), CliError> {
                 model: args.model.clone(),
                 variant: args.variant.clone(),
                 agent_version: args.agent_version.clone(),
+                raw_session_args: None,
+                raw_session_options: None,
             };
             let path = format!("{API_PREFIX}/sessions/{}", args.session_id);
             let response = ctx.post(&path, &body)?;

--- a/server/packages/sandbox-agent/src/opencode_compat.rs
+++ b/server/packages/sandbox-agent/src/opencode_compat.rs
@@ -379,6 +379,8 @@ async fn ensure_backing_session(
         model: None,
         variant: None,
         agent_version: None,
+        raw_session_args: None,
+        raw_session_options: None,
     };
     match state
         .inner

--- a/server/packages/sandbox-agent/tests/agent-management/mod.rs
+++ b/server/packages/sandbox-agent/tests/agent-management/mod.rs
@@ -1,1 +1,2 @@
 mod agents;
+mod raw_session_args;

--- a/server/packages/sandbox-agent/tests/agent-management/raw_session_args.rs
+++ b/server/packages/sandbox-agent/tests/agent-management/raw_session_args.rs
@@ -1,0 +1,50 @@
+use sandbox_agent_agent_management::agents::{AgentId, AgentManager, InstallOptions, SpawnOptions};
+
+/// Tests that raw_args are passed to CLI-based agents.
+/// We use `--version` as a raw arg which causes agents to print version info and exit.
+#[test]
+fn test_raw_args_version_flag() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let manager = AgentManager::new(temp_dir.path().join("bin"))?;
+
+    // Test Claude with --version
+    manager.install(AgentId::Claude, InstallOptions::default())?;
+    let mut spawn = SpawnOptions::new("test");
+    spawn.raw_args = vec!["--version".to_string()];
+    let result = manager.spawn(AgentId::Claude, spawn)?;
+    let output = format!("{}{}", result.stdout, result.stderr);
+    assert!(
+        output.to_lowercase().contains("version")
+            || output.contains("claude")
+            || result.status.code() == Some(0),
+        "Claude --version failed: {output}"
+    );
+
+    // Test OpenCode with --version
+    manager.install(AgentId::Opencode, InstallOptions::default())?;
+    let mut spawn = SpawnOptions::new("test");
+    spawn.raw_args = vec!["--version".to_string()];
+    let result = manager.spawn(AgentId::Opencode, spawn)?;
+    let output = format!("{}{}", result.stdout, result.stderr);
+    assert!(
+        output.to_lowercase().contains("version")
+            || output.contains("opencode")
+            || result.status.code() == Some(0),
+        "OpenCode --version failed: {output}"
+    );
+
+    // Test Amp with --version
+    manager.install(AgentId::Amp, InstallOptions::default())?;
+    let mut spawn = SpawnOptions::new("test");
+    spawn.raw_args = vec!["--version".to_string()];
+    let result = manager.spawn(AgentId::Amp, spawn)?;
+    let output = format!("{}{}", result.stdout, result.stderr);
+    assert!(
+        output.to_lowercase().contains("version")
+            || output.contains("amp")
+            || result.status.code() == Some(0),
+        "Amp --version failed: {output}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Adds `rawSessionArgs` and `rawSessionOptions` fields to `CreateSessionRequest` for passing raw CLI arguments and options directly to agents at session creation
- Implements `apply_raw_options_as_cli_args` to convert JSON key-value pairs to `--key value` CLI flags for CLI-based agents (Claude, OpenCode, Amp)
- For Codex (JSON-RPC), raw options are merged into the `thread/start` config
- Updates agent capabilities to advertise `rawSessionArgs` and `rawSessionOptions` support
- Updates TypeScript SDK types, OpenAPI spec, docs, and agent research

## Test plan
- [ ] Verify `rawSessionArgs` are appended to CLI agent spawn commands
- [ ] Verify `rawSessionOptions` are converted to `--key value` flags for CLI agents
- [ ] Verify `rawSessionOptions` are merged into Codex JSON-RPC config
- [ ] Verify boolean true/false handling in raw options (true → `--flag`, false → skipped)
- [ ] Run `cargo test -p sandbox-agent --test agent_management`