### PR TITLE
fix: support Claude OAuth token model discovery for Gigacode/OpenCode

### DIFF
--- a/server/ARCHITECTURE.md
+++ b/server/ARCHITECTURE.md
@@ -261,7 +261,7 @@ All agents receive API keys via environment variables:
 
 | Agent | Environment Variables |
 |-------|----------------------|
-| Claude | `ANTHROPIC_API_KEY`, `CLAUDE_API_KEY` |
+| Claude | `ANTHROPIC_API_KEY`, `CLAUDE_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_AUTH_TOKEN` |
 | Codex | `OPENAI_API_KEY`, `CODEX_API_KEY` |
 | OpenCode | `OPENAI_API_KEY` |
 | Amp | `ANTHROPIC_API_KEY` |


### PR DESCRIPTION
## Summary

Support `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_AUTH_TOKEN` as Anthropic credential sources. When Anthropic's `/v1/models` rejects OAuth auth, fall back to a hardcoded Claude model set (`default`, `opus`, `haiku`).

## Problem

OpenCode model discovery needs `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_AUTH_TOKEN`. Without an `ANTHROPIC_API_KEY`, the `/v1/models` call fails with OAuth tokens, causing Claude to disappear from provider lists.

## Changes

- **`agent-credentials/src/lib.rs`**: Extract `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_AUTH_TOKEN` as OAuth credentials (lower priority than API key env vars)
- **`sandbox-agent/src/router.rs`**: Return fallback model list when Anthropic rejects OAuth or returns empty results
- **`ARCHITECTURE.md`**: Document the new env vars

## Validation

3 new unit tests + live verified with only `CLAUDE_CODE_OAUTH_TOKEN` set (no API key):
- `/models` returns 3 fallback models
- `/providers` includes Claude