### PR TITLE
fix: use actual opencode url

### DIFF
--- a/docs/opencode-compatibility.mdx
+++ b/docs/opencode-compatibility.mdx
@@ -64,6 +64,7 @@ The OpenCode web UI can connect to Sandbox Agent for a full browser-based experi
     cd opencode/packages/app
     export VITE_OPENCODE_SERVER_HOST=127.0.0.1
     export VITE_OPENCODE_SERVER_PORT=2468
+    bun install
     bun run dev -- --host 127.0.0.1 --port 5173
     ```
   </Step>


### PR DESCRIPTION
the url in the docs was incorrect