### PR TITLE
Fix Pi agent credentials

### DIFF
--- a/docs/credentials.mdx
+++ b/docs/credentials.mdx
@@ -45,6 +45,7 @@ OAuth tokens (used when OAuth extraction is enabled):
 | Amp | Anthropic |
 | Codex | OpenAI |
 | OpenCode | Anthropic or OpenAI |
+| Pi | Any supported provider API key (Anthropic, OpenAI, Gemini, etc.) |
 | Mock | None |
 
 ## Error handling behavior


### PR DESCRIPTION
## Summary
Fixed Pi agent functionality by implementing credential extraction and environment variable injection. The agent now:
- Extracts credentials from all supported providers (Anthropic, OpenAI, Gemini, etc.) using `extract_all_credentials()`
- Merges provider API keys into the agent runtime environment via `merge_credentials_env()`
- Checks for any available API key credentials to determine if Pi agent is available
- Updates credential availability logic across router endpoints to support multiple providers
- Documents that Pi agent accepts any supported provider API key in `credentials.mdx`

The fix ensures Pi agent receives necessary API keys at runtime and properly reports credential availability status. 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/tasks/98f1e100-ea68-4698-8269-2e4c73793b60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/agents"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.2-codex:high?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.2-codex:high?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.2-codex:high?theme=light&v=11" height="28"></picture></a> 