### PR TITLE
docs: clean up Agent Computer references

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -56,13 +56,13 @@
                   "deploy/local",
                   "deploy/e2b",
                   "deploy/daytona",
-                  "deploy/agentcomputer",
                   "deploy/vercel",
                   "deploy/cloudflare",
                   "deploy/docker",
                   "deploy/modal",
                   "deploy/boxlite",
-                  "deploy/computesdk"
+                  "deploy/computesdk",
+                  "deploy/agentcomputer"
                 ]
               }
             ]

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -68,6 +68,13 @@ icon: "rocket"
           server --no-token --host 0.0.0.0 --port 2468
         ```
       </Tab>
+
+      <Tab title="Agent Computer">
+        ```bash
+        export COMPUTER_API_KEY="ac_live_..."
+        # Agent auth usually stays inside your managed-worker image or default machine source.
+        ```
+      </Tab>
     </Tabs>
 
     <AccordionGroup>
@@ -173,7 +180,7 @@ icon: "rocket"
 
     <AccordionGroup>
       <Accordion title="Configuring token">
-        Tokens are usually not required. Most sandbox providers (E2B, Daytona, etc.) already secure networking at the infrastructure layer.
+        Tokens are usually not required. Most sandbox providers (E2B, Daytona, Agent Computer, etc.) already secure networking at the infrastructure layer.
 
         If you expose the server publicly, use `--token "$SANDBOX_TOKEN"` to require authentication:
 
@@ -298,7 +305,7 @@ icon: "rocket"
     Configure in-memory, Rivet Actor state, IndexedDB, SQLite, and Postgres persistence.
   </Card>
   <Card title="Deploy to a Sandbox" icon="box" href="/deploy/local">
-    Deploy your agent to E2B, Daytona, Docker, Vercel, or Cloudflare.
+    Deploy your agent to E2B, Daytona, Docker, Vercel, Cloudflare, or Agent Computer.
   </Card>
   <Card title="SDK Overview" icon="compass" href="/sdk-overview">
     Use the latest TypeScript SDK API.

--- a/docs/sdk-overview.mdx
+++ b/docs/sdk-overview.mdx
@@ -98,9 +98,9 @@ await sdk.destroySandbox(); // provider-defined cleanup + disposes client
 | `sandbox-agent/docker` | Docker container |
 | `sandbox-agent/e2b` | E2B sandbox |
 | `sandbox-agent/daytona` | Daytona workspace |
-| `sandbox-agent/agentcomputer` | Agent Computer managed worker |
 | `sandbox-agent/vercel` | Vercel Sandbox |
 | `sandbox-agent/cloudflare` | Cloudflare Sandbox |
+| `sandbox-agent/agentcomputer` | Agent Computer managed worker |
 
 Use `sdk.dispose()` to disconnect without changing sandbox state, `sdk.pauseSandbox()` for graceful suspension when supported, or `sdk.killSandbox()` for permanent deletion.
 

--- a/frontend/packages/website/src/components/FAQ.tsx
+++ b/frontend/packages/website/src/components/FAQ.tsx
@@ -21,12 +21,12 @@ const faqs = [
   },
   {
     question: "Can I run this locally or does it require a sandbox provider?",
-    answer: "Both. Run locally for development, deploy to E2B, Daytona, or Vercel Sandboxes for production.",
+    answer: "Both. Run locally for development, deploy to E2B, Daytona, Vercel, or Agent Computer Sandboxes for production.",
   },
   {
     question: "Does it support [platform]?",
     answer:
-      "The server is a single Rust binary that runs anywhere with a curl install. If your platform can run Linux binaries (Docker, VMs, etc.), it works. See the deployment guides for E2B, Daytona, and Vercel Sandboxes.",
+      "The server is a single Rust binary that runs anywhere with a curl install. If your platform can run Linux binaries (Docker, VMs, etc.), it works. See the deployment guides for E2B, Daytona, Vercel, and Agent Computer Sandboxes.",
   },
   {
     question: "Can I use this with my personal API keys?",

--- a/frontend/packages/website/src/components/FeatureGrid.tsx
+++ b/frontend/packages/website/src/components/FeatureGrid.tsx
@@ -83,7 +83,7 @@ export function FeatureGrid() {
               <h4 className="text-base font-normal text-white">Runs Inside Any Sandbox</h4>
             </div>
             <p className="text-zinc-500 text-sm leading-relaxed">
-              Lightweight static binary. One curl command to install inside E2B, Daytona, Vercel Sandboxes, or Docker.
+              Lightweight static binary. One curl command to install inside E2B, Daytona, Vercel Sandboxes, Docker, or Agent Computer.
             </p>
           </div>
 

--- a/frontend/packages/website/src/components/Integrations.tsx
+++ b/frontend/packages/website/src/components/Integrations.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-const integrations = ["Daytona", "E2B", "AI SDK", "Anthropic", "OpenAI", "Docker", "Fly.io", "AWS Nitro", "Postgres", "ClickHouse", "Rivet"];
+const integrations = ["Daytona", "E2B", "AI SDK", "Anthropic", "OpenAI", "Docker", "Fly.io", "AWS Nitro", "Postgres", "ClickHouse", "Rivet", "Agent Computer"];
 
 export function Integrations() {
   return (


### PR DESCRIPTION
Moves Agent Computer docs and website references into cleaner ordering.

Also updates the docs sidebar entry order in docs.json.