### PR TITLE
feat(opencode): expose built-in TUI commands via GET /opencode/command

### DIFF
--- a/server/packages/opencode-adapter/src/lib.rs
+++ b/server/packages/opencode-adapter/src/lib.rs
@@ -924,7 +924,50 @@ async fn oc_command_list(State(state): State<Arc<AdapterState>>, headers: Header
     {
         return response;
     }
-    (StatusCode::OK, Json(json!([]))).into_response()
+    // No native OpenCode proxy is available (e.g. Claude Code mode). Previously
+    // this returned `[]`, leaving the built-in TUI commands (compact, clear,
+    // scroll, etc.) undiscoverable via the API. Surface them here so frontends
+    // can render a complete command palette without depending on a native
+    // OpenCode server.
+    (StatusCode::OK, Json(Value::Array(builtin_tui_commands()))).into_response()
+}
+
+/// Built-in TUI commands exposed by the OpenCode TUI client via
+/// `EventTuiCommandExecute` and executable through `POST /tui/execute-command`.
+///
+/// These are actions (not prompt-template commands), so they are returned with
+/// a `type: "builtin"` discriminator alongside the `name`/`description` a
+/// command palette needs, to distinguish them from custom/user commands.
+fn builtin_tui_commands() -> Vec<Value> {
+    const BUILTINS: &[(&str, &str)] = &[
+        ("session.compact", "Compact/summarize context"),
+        ("session.list", "List sessions"),
+        ("session.new", "Create new session"),
+        ("session.share", "Share session"),
+        ("session.interrupt", "Interrupt current generation"),
+        ("prompt.clear", "Clear prompt input"),
+        ("prompt.submit", "Submit prompt"),
+        ("agent.cycle", "Cycle between agents"),
+        ("session.page.up", "Scroll page up"),
+        ("session.page.down", "Scroll page down"),
+        ("session.line.up", "Scroll line up"),
+        ("session.line.down", "Scroll line down"),
+        ("session.half.page.up", "Scroll half page up"),
+        ("session.half.page.down", "Scroll half page down"),
+        ("session.first", "Jump to first message"),
+        ("session.last", "Jump to last message"),
+    ];
+
+    BUILTINS
+        .iter()
+        .map(|(name, description)| {
+            json!({
+                "name": name,
+                "description": description,
+                "type": "builtin",
+            })
+        })
+        .collect()
 }
 
 async fn oc_config_get(State(state): State<Arc<AdapterState>>, headers: HeaderMap) -> Response {


### PR DESCRIPTION
## Summary

Closes #142.

`GET /opencode/command` previously returned `[]` when no native OpenCode proxy is configured (e.g. Claude Code mode), so the built-in TUI commands (`session.compact`, `prompt.clear`, scroll actions, etc.) were undiscoverable via the API. Frontends/Gigacode had no way to list the full command set without a native OpenCode server.

This change returns the built-in command set in that fallback path, covering every command from the issue's `EventTuiCommandExecute` list.

## Shape

Built-in TUI commands are *actions*, not prompt-template commands, so they don't fit the custom-command shape cleanly. They're returned as:

```json
{ "name": "session.compact", "description": "Compact/summarize context", "type": "builtin" }
```

The `type: "builtin"` discriminator lets a frontend distinguish them from custom/user commands while still rendering them in a palette. Happy to adjust the shape if you'd prefer something else.

## Scope / notes

- Fix is in the mounted handler `oc_command_list` (`server/packages/opencode-adapter/src/lib.rs`); the native-proxy path is unchanged.
- When a native OpenCode proxy *is* configured, its response is still returned as-is. Merging the built-ins into the proxied custom-command list is a natural follow-up if you want `/command` to be exhaustive in that mode too; I kept this PR scoped to the no-proxy case (issue goal #3).
- I have not run a local `cargo` build for this change; it's a small, self-contained addition using already-imported types. Please flag if CI surfaces anything and I'll fix it.