### PR TITLE
fix(acp): add explicit SSE response fences

### DIFF
--- a/research/acp/friction.md
+++ b/research/acp/friction.md
@@ -287,3 +287,14 @@ Update this file continuously during the migration.
 - Owner: Unassigned.
 - Status: resolved
 - Links: `server/packages/sandbox-agent/src/router.rs`, `server/packages/sandbox-agent/src/desktop_runtime.rs`, `sdks/typescript/src/client.ts`, `frontend/packages/inspector/src/components/debug/DesktopTab.tsx`
+
+- Date: 2026-07-16
+- Area: ACP direct-response and SSE terminal ordering
+- Issue: The adapter completed the waiting HTTP `POST` before assigning and broadcasting the same JSON-RPC response on SSE. A client consuming both paths could therefore persist `stopReason=end_turn` before earlier `session/update` chunks reached its SSE callback.
+- Impact: Durable event indexes could place terminal completion before the final assistant chunks even though agent stdout itself was ordered.
+- Proposed direction: Assign the response's monotonic SSE sequence first, expose it as `result._meta["sandboxagent.dev"].streamFence.sequence`, put the exact fenced response in the replay ring and broadcast it, and only then release the HTTP waiter. Consumers use the SSE copy as the authoritative terminal boundary.
+- Decision: Accepted and implemented as additive transport metadata. Consumer correctness must also
+  hold with legacy adapters by treating their existing correlated SSE response as authoritative.
+- Owner: Unassigned.
+- Status: resolved
+- Links: `server/packages/acp-http-adapter/src/process.rs`, `server/packages/acp-http-adapter/tests/e2e.rs`, `research/acp/simplify-server.md`

--- a/research/acp/simplify-server.md
+++ b/research/acp/simplify-server.md
@@ -62,6 +62,9 @@ Sandbox Agent does not inspect ACP method semantics.
 
 - `POST` accepts one JSON-RPC envelope.
 - If envelope is request (`method` + `id`): wait for matching stdio response and return `200` + JSON body.
+- Before completing a request whose response has an object `result`, assign its SSE sequence and add
+  `result._meta["sandboxagent.dev"].streamFence.sequence`. Store and broadcast that exact fenced
+  response before releasing the waiting `POST`.
 - If envelope is notification or response without `method`: forward and return `202` empty.
 - `GET` streams agent->client messages as SSE.
 - Replay semantics remain: `Last-Event-ID` supported using in-memory ring buffer per `{server_id}`.
@@ -75,6 +78,12 @@ Same framing as current transport profile:
 - `id: <monotonic sequence per server_id>`
 - `data: <single JSON-RPC object>`
 - keepalive comment heartbeat every 15s
+
+The SSE copy is the authoritative ordering path for clients that consume both channels. Existing
+adapter versions already broadcast the response after preceding notifications, so clients can use
+the correlated SSE response without requiring this metadata. The response fence additionally makes
+the terminal sequence explicit: when the fenced SSE envelope arrives, all lower sequences have
+already entered the replay ring.
 
 ### 3.5 Process Model
 

--- a/server/packages/acp-http-adapter/src/process.rs
+++ b/server/packages/acp-http-adapter/src/process.rs
@@ -401,23 +401,26 @@ impl AdapterRuntime {
                 if is_response {
                     let key = id_key(payload.get("id").expect("checked"));
                     let has_error = payload.get("error").is_some();
-                    if let Some(tx) = pending.lock().await.remove(&key) {
+                    let response_waiter = {
+                        let mut pending = pending.lock().await;
+                        pending.remove(&key)
+                    };
+                    if let Some(tx) = response_waiter {
                         tracing::debug!(
                             id = %key,
                             has_error = has_error,
                             age_ms = spawned_at.elapsed().as_millis() as u64,
                             "agent stdout: response matched to pending request"
                         );
-                        let _ = tx.send(payload.clone());
-                        // Also broadcast the response so SSE/notification subscribers
-                        // see it in order after preceding notifications. This lets the
-                        // SSE translation task detect turn completion after all
-                        // session/update events have been processed.
                         let seq = sequence.fetch_add(1, Ordering::SeqCst) + 1;
+                        let payload = attach_stream_fence(payload, seq);
                         let message = StreamMessage {
                             sequence: seq,
-                            payload,
+                            payload: payload.clone(),
                         };
+                        // The SSE ring is the authoritative ordering boundary. Publish the fenced
+                        // response there before releasing the HTTP waiter, so a direct terminal
+                        // response can never claim completion ahead of preceding notifications.
                         {
                             let mut guard = ring.lock().await;
                             guard.push_back(message.clone());
@@ -426,6 +429,7 @@ impl AdapterRuntime {
                             }
                         }
                         let _ = sender.send(message);
+                        let _ = tx.send(payload);
                         continue;
                     } else {
                         tracing::warn!(
@@ -622,4 +626,81 @@ impl AdapterRuntime {
 
 fn id_key(value: &Value) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| "null".to_string())
+}
+
+/// Adds the response's authoritative SSE sequence without disturbing existing ACP metadata.
+fn attach_stream_fence(mut payload: Value, sequence: u64) -> Value {
+    let Some(result) = payload.get_mut("result").and_then(Value::as_object_mut) else {
+        return payload;
+    };
+    let metadata = result.entry("_meta").or_insert_with(|| json!({}));
+    if !metadata.is_object() {
+        tracing::warn!(
+            sequence,
+            "response _meta is not an object; replacing it to attach stream fence"
+        );
+        *metadata = json!({});
+    }
+    let metadata = metadata
+        .as_object_mut()
+        .expect("metadata normalized to object");
+    let namespace = metadata
+        .entry("sandboxagent.dev")
+        .or_insert_with(|| json!({}));
+    if !namespace.is_object() {
+        tracing::warn!(
+            sequence,
+            "response sandboxagent.dev metadata is not an object; replacing it to attach stream fence"
+        );
+        *namespace = json!({});
+    }
+    let namespace = namespace
+        .as_object_mut()
+        .expect("sandboxagent.dev metadata normalized to object");
+    namespace.insert("streamFence".to_string(), json!({ "sequence": sequence }));
+    payload
+}
+
+#[cfg(test)]
+mod tests {
+    use super::attach_stream_fence;
+    use serde_json::json;
+
+    #[test]
+    fn stream_fence_preserves_existing_metadata() {
+        let fenced = attach_stream_fence(
+            json!({
+                "result": {
+                    "_meta": {
+                        "existing": true,
+                        "sandboxagent.dev": {"existing": "value"}
+                    }
+                }
+            }),
+            42,
+        );
+
+        assert_eq!(fenced["result"]["_meta"]["existing"], true);
+        assert_eq!(
+            fenced["result"]["_meta"]["sandboxagent.dev"]["existing"],
+            "value"
+        );
+        assert_eq!(
+            fenced["result"]["_meta"]["sandboxagent.dev"]["streamFence"]["sequence"],
+            42
+        );
+    }
+
+    #[test]
+    fn stream_fence_replaces_malformed_metadata_to_keep_the_contract() {
+        let fenced = attach_stream_fence(
+            json!({"result": {"_meta": {"sandboxagent.dev": "invalid"}}}),
+            7,
+        );
+
+        assert_eq!(
+            fenced["result"]["_meta"]["sandboxagent.dev"]["streamFence"]["sequence"],
+            7
+        );
+    }
 }

--- a/server/packages/acp-http-adapter/tests/e2e.rs
+++ b/server/packages/acp-http-adapter/tests/e2e.rs
@@ -37,6 +37,15 @@ async fn health_and_request_response_round_trip() {
     let health_json: Value = health.json().await.expect("health json");
     assert_eq!(health_json["ok"], true);
 
+    let sse_response = client
+        .get(format!("{}/v1/rpc", adapter.base_url))
+        .header("accept", "text/event-stream")
+        .send()
+        .await
+        .expect("open sse");
+    assert_eq!(sse_response.status(), StatusCode::OK);
+    let mut sse = SseReader::new(sse_response);
+
     let payload = json!({
         "jsonrpc": "2.0",
         "id": 1,
@@ -59,6 +68,21 @@ async fn health_and_request_response_round_trip() {
     assert_eq!(body["id"], 1);
     assert_eq!(body["result"]["echoed"]["method"], "mock/ping");
     assert_eq!(body["result"]["echoed"]["params"]["text"], "hello");
+
+    let fence_sequence = body["result"]["_meta"]["sandboxagent.dev"]["streamFence"]["sequence"]
+        .as_u64()
+        .expect("terminal response stream fence");
+    let notification = sse
+        .next_event(Duration::from_secs(3))
+        .await
+        .expect("notification before terminal");
+    assert_eq!(notification.data["method"], "mock/echo");
+    let terminal = sse
+        .next_event(Duration::from_secs(3))
+        .await
+        .expect("terminal response event");
+    assert_eq!(terminal.id, Some(fence_sequence));
+    assert_eq!(terminal.data, body);
 }
 
 #[tokio::test]
@@ -154,6 +178,11 @@ struct SseReader {
     buffer: Vec<u8>,
 }
 
+struct ParsedSseEvent {
+    id: Option<u64>,
+    data: Value,
+}
+
 impl SseReader {
     fn new(response: reqwest::Response) -> Self {
         Self {
@@ -163,6 +192,10 @@ impl SseReader {
     }
 
     async fn next_json(&mut self, timeout: Duration) -> io::Result<Value> {
+        Ok(self.next_event(timeout).await?.data)
+    }
+
+    async fn next_event(&mut self, timeout: Duration) -> io::Result<ParsedSseEvent> {
         let deadline = Instant::now() + timeout;
 
         loop {
@@ -197,7 +230,7 @@ impl SseReader {
         }
     }
 
-    fn try_parse_event(&mut self) -> io::Result<Option<Value>> {
+    fn try_parse_event(&mut self) -> io::Result<Option<ParsedSseEvent>> {
         let split = self
             .buffer
             .windows(2)
@@ -231,6 +264,15 @@ impl SseReader {
             return Ok(None);
         }
 
+        let id = text
+            .lines()
+            .find_map(|line| line.strip_prefix("id: "))
+            .map(str::parse::<u64>)
+            .transpose()
+            .map_err(|err| {
+                io::Error::new(io::ErrorKind::InvalidData, format!("invalid sse id: {err}"))
+            })?;
+
         let value: Value = serde_json::from_str(&data).map_err(|err| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -238,7 +280,7 @@ impl SseReader {
             )
         })?;
 
-        Ok(Some(value))
+        Ok(Some(ParsedSseEvent { id, data: value }))
     }
 }
 


### PR DESCRIPTION
## What changed

- Assign the matched JSON-RPC response its SSE sequence before completing the waiting HTTP `POST`.
- Add that sequence at `result._meta["sandboxagent.dev"].streamFence.sequence`.
- Store and broadcast the exact fenced payload before releasing the HTTP waiter.
- Preserve existing metadata and normalize malformed extension metadata so object-result responses do not silently lose the fence.
- Document that the fence is additive: legacy adapters already publish the correlated response on FIFO SSE, so consumers must not require this metadata for correctness.

## Why

Clients that consume both the direct HTTP response and SSE stream need an explicit terminal watermark for diagnostics and replay. Publishing the fenced SSE copy first makes the final sequence unambiguous while retaining compatibility with older clients and adapters.

## Verification

- `cargo fmt --all --check`
- `cargo test --offline -p acp-http-adapter`
  - unit tests: 2/2 passed
  - E2E tests: 2/2 passed
  - doc tests passed

A downstream Agent Session fix independently preserves ordering with old unfenced Sandbox Agent versions; this PR adds the explicit watermark and does not serve as its correctness prerequisite.
