### PR TITLE
fix(acp-http-client): isolate detached POST failures

### DIFF
--- a/sdks/acp-http-client/src/index.ts
+++ b/sdks/acp-http-client/src/index.ts
@@ -404,8 +404,22 @@ class StreamableHttpAcpTransport {
       await response.text().catch(() => {});
     } catch (error) {
       console.error("ACP write error:", error);
-      this.failReadable(error);
+      this.handleDetachedRequestError(message, error);
     }
+  }
+
+  private handleDetachedRequestError(message: AnyMessage, error: unknown): void {
+    const id = requestIdFromMessage(message);
+    if (id === undefined) {
+      this.failReadable(error);
+      return;
+    }
+
+    this.pushInbound({
+      jsonrpc: "2.0",
+      id,
+      error: toRpcError(error),
+    } as AnyMessage);
   }
 
   private ensureSseLoop(): void {
@@ -675,6 +689,37 @@ function responseEnvelopeId(message: AnyMessage): string | null {
     return null;
   }
   return String(id);
+}
+
+function requestIdFromMessage(message: AnyMessage): number | string | null | undefined {
+  if (typeof message !== "object" || message === null || !Object.hasOwn(message, "id")) {
+    return undefined;
+  }
+  const id = (message as Record<string, unknown>).id;
+  if (typeof id === "string" || typeof id === "number" || id === null) {
+    return id;
+  }
+  return undefined;
+}
+
+function toRpcError(error: unknown): RpcErrorResponse {
+  if (error instanceof AcpHttpError) {
+    return {
+      code: -32003,
+      message: error.problem?.title ?? `HTTP ${error.status}`,
+      data: error.problem ?? { status: error.status },
+    };
+  }
+  if (error instanceof Error) {
+    return {
+      code: -32603,
+      message: error.message,
+    };
+  }
+  return {
+    code: -32603,
+    message: String(error),
+  };
 }
 
 async function readProblem(response: Response): Promise<ProblemDetails | undefined> {

--- a/sdks/acp-http-client/tests/smoke.test.ts
+++ b/sdks/acp-http-client/tests/smoke.test.ts
@@ -181,4 +181,50 @@ describe("AcpHttpClient integration", () => {
 
     await client.disconnect();
   });
+
+  it("keeps the SSE connection usable after a request POST fails", async () => {
+    const serverId = `acp-http-client-post-failure-${Date.now().toString(36)}`;
+    let failNextPrompt = true;
+    const faultInjectingFetch: typeof fetch = async (input, init) => {
+      if (failNextPrompt && init?.method === "POST" && typeof init.body === "string") {
+        const envelope = JSON.parse(init.body) as { method?: string };
+        if (envelope.method === "session/prompt") {
+          failNextPrompt = false;
+          throw new TypeError("simulated request POST failure");
+        }
+      }
+      return globalThis.fetch(input, init);
+    };
+
+    const client = new AcpHttpClient({
+      baseUrl,
+      token,
+      fetch: faultInjectingFetch,
+      transport: {
+        path: `/v1/acp/${encodeURIComponent(serverId)}`,
+        bootstrapQuery: { agent: "mock" },
+      },
+    });
+
+    await client.initialize();
+    const session = await client.newSession({
+      cwd: process.cwd(),
+      mcpServers: [],
+    });
+
+    await expect(
+      client.prompt({
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "fail this request" }],
+      }),
+    ).rejects.toThrow("simulated request POST failure");
+
+    const prompt = await client.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "connection still works" }],
+    });
+    expect(prompt.stopReason).toBe("end_turn");
+
+    await client.disconnect();
+  });
 });


### PR DESCRIPTION
## Summary
- reject only the matching JSON-RPC request when its detached POST fails
- preserve the shared SSE transport so later requests can continue
- add a real-server integration test covering failure followed by a successful prompt

## Motivation
`postMessage` runs detached so long-running requests do not block client replies. A network failure in one detached POST currently errors the shared readable stream, terminating an otherwise healthy SSE connection and every pending or subsequent request.

## Rationale
Requests already have JSON-RPC IDs, so a POST failure can be represented as an error response for that request. Notifications have no response to reject and retain the existing transport-fatal behavior.

The broader proposal to return `202 Accepted` for long-running requests and deliver completion over SSE is tracked separately in #305.

## Test plan
- [x] `pnpm --filter acp-http-client typecheck`
- [x] build `sandbox-agent` and run `pnpm --filter acp-http-client test`
- [x] verify a failed prompt POST rejects that prompt and a second prompt succeeds on the same connection

Fixes #307