### PR TITLE
fix: restore ctrl+c handling in gigacode (fixes #111)

### DIFF
--- a/sdks/gigacode/bin/gigacode
+++ b/sdks/gigacode/bin/gigacode
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const { execFileSync } = require("child_process");
+const { spawn } = require("child_process");
 const {
   assertExecutable,
   formatNonExecutableBinaryMessage,
@@ -59,7 +59,35 @@ try {
     process.exit(1);
   }
 
-  execFileSync(binPath, process.argv.slice(2), { stdio: "inherit" });
+  const child = spawn(binPath, process.argv.slice(2), {
+    stdio: "inherit",
+  });
+
+  const forwardSignal = (signal) => {
+    if (!child.killed) {
+      child.kill(signal);
+    }
+  };
+
+  const onSigint = () => forwardSignal("SIGINT");
+  const onSigterm = () => forwardSignal("SIGTERM");
+  const onSigquit = () => forwardSignal("SIGQUIT");
+
+  process.on("SIGINT", onSigint);
+  process.on("SIGTERM", onSigterm);
+  process.on("SIGQUIT", onSigquit);
+
+  child.on("exit", (code, signal) => {
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
+    process.off("SIGQUIT", onSigquit);
+
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 0);
+  });
 } catch (e) {
   if (e.status !== undefined) process.exit(e.status);
   throw e;


### PR DESCRIPTION
## Description
This PR fixes an issue where the `gigacode` CLI does not gracefully exit when `Ctrl+C` is pressed. 

**Root Cause:** The Node.js wrapper script was executing the underlying Rust binary synchronously using `execFileSync`. This blocked the Node event loop and prevented signals like `SIGINT` from properly reaching the child process.

**Changes:**
- Replaced `execFileSync` with asynchronous `spawn`.
- Added explicit signal forwarding for `SIGINT`, `SIGTERM`, and `SIGQUIT` from the parent Node process to the child Rust process.
- Ensured the parent process waits to exit until the child process completes its shutdown.

Fixes #111 
