### PR TITLE
fix: preserve insertion order for model variants in opencode API (fixes #145)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ acp-http-adapter = { version = "0.4.2", path = "server/packages/acp-http-adapter
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 
 # Error handling
 thiserror = "1.0"


### PR DESCRIPTION
## Description
This PR fixes an issue where Codex model variants were being returned out of order in the OpenCode `/models` API (e.g. `["high", "low", "medium", "xhigh"]`).

**Root Cause:** The `opencode_compat` handler manually builds the variants object, but `serde_json` uses `BTreeMap` by default, which inadvertently sorted the keys alphabetically during serialization. 

**Changes:**
- Enabled the `preserve_order` feature for `serde_json` in the workspace `Cargo.toml`. This swaps the underlying map implementation to `IndexMap`, preserving the logical insertion order defined by the agent configs.

Fixes #145
